### PR TITLE
fix(python): assign missing metadata default value

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "visionai-data-format"
-PACKAGE_VERSION = "0.1.1"
+PACKAGE_VERSION = "0.1.2"
 DESC = "converter tool for visionai format"
 
 setup(

--- a/visionai_data_format/schemas/visionai_schema.py
+++ b/visionai_data_format/schemas/visionai_schema.py
@@ -465,7 +465,7 @@ class Metadata(BaseModel):
         extra = Extra.allow
 
     schema_version: SchemaVersion = Field(
-        ...,
+        default=SchemaVersion.field_1_0_0,
         description="Version number of the VisionAI schema this annotation JSON object follows.",
     )
 
@@ -566,7 +566,7 @@ class VisionAI(BaseModel):
 
     streams: Stream = Field(default_factory=dict)
 
-    metadata: Metadata = Field(default_factory=dict)
+    metadata: Metadata = Field(default_factory=Metadata)
 
 
 class VisionAIModel(BaseModel):


### PR DESCRIPTION
## Purpose

as mentioned. we need to assign metadata value such as `schema_version` automatically.

## What Changes?

- assign current schema version default value

## What to Check?

- It should work.