### PR TITLE
fix(python): fix wrong default_factory value

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "visionai-data-format"
-PACKAGE_VERSION = "0.1.2"
+PACKAGE_VERSION = "0.1.3a"
 DESC = "converter tool for visionai format"
 
 setup(

--- a/visionai_data_format/schemas/visionai_schema.py
+++ b/visionai_data_format/schemas/visionai_schema.py
@@ -546,7 +546,7 @@ class VisionAI(BaseModel):
     )
 
     frame_intervals: Optional[list[FrameInterval]] = Field(
-        default_factory=dict, description="This is an array of frame intervals."
+        default_factory=list, description="This is an array of frame intervals."
     )
     frames: Optional[dict[str, Frame]] = Field(
         default_factory=dict,


### PR DESCRIPTION
## Purpose

as mentioned. wrong `default_factory` type for `frame_intervals` field

## What Changes?

- assign with right default value

## What to Check?

- It should work.