### PR TITLE
feat(python): add new semantic format related fields

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "visionai-data-format"
-PACKAGE_VERSION = "0.1.7"
+PACKAGE_VERSION = "0.1.8"
 DESC = "converter tool for visionai format"
 REQUIRED = ["pydantic"]
 REQUIRES_PYTHON = ">=3.7, <4"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -47,6 +47,7 @@ def test_visionai_model():
             "objects": {},
             "coordinate_systems": {},
             "streams": {},
+            "tags": {},
             "metadata": {"schema_version": "1.0.0"},
         }
     }
@@ -62,6 +63,7 @@ def test_visionai():
         "objects": {},
         "coordinate_systems": {},
         "streams": {},
+        "tags": {},
     }
     generated_data = {
         "contexts": {},
@@ -70,6 +72,7 @@ def test_visionai():
         "objects": {},
         "coordinate_systems": {},
         "streams": {},
+        "tags": {},
         "metadata": {"schema_version": "1.0.0"},
     }
 

--- a/visionai_data_format/schemas/visionai_schema.py
+++ b/visionai_data_format/schemas/visionai_schema.py
@@ -568,7 +568,7 @@ class CoordinateSystem(BaseModel):
 
 
 class TagData(BaseModel):
-    vec: List[VecBase] = Field(default_factory=list)
+    vec: List[VecBase] = Field(...)
 
 
 class Tag(BaseModel):

--- a/visionai_data_format/schemas/visionai_schema.py
+++ b/visionai_data_format/schemas/visionai_schema.py
@@ -37,6 +37,7 @@ class ObjectType(str, Enum):
     number = "number"
     vec = "vec"
     text = "text"
+    binary = "binary"
 
 
 class TypeMinMax(str, Enum):
@@ -144,6 +145,25 @@ class Matrix(ObjectDataElement):
         return value
 
 
+class Binary(ObjectDataElement):
+    encoding: Literal["rle"] = Field(
+        ..., description="The encoding method. It only supports “rle“ value."
+    )
+    data_type: Literal[""] = Field(
+        ...,
+        description="This is a string declares the type of values of the binary."
+        + " Only empty string "
+        " value allowed",
+    )
+    val: StrictStr = Field(...)
+
+    @validator("name")
+    def validate_name_field(cls, value):
+        if value != "semantic_mask":
+            raise ValueError("Name value must be `semantic_mask`")
+        return value
+
+
 class Bbox(ObjectDataElement):
     class Config:
         extra = Extra.allow
@@ -222,13 +242,8 @@ class Text(BaseModel):
     )
 
 
-class Vec(BaseModel):
+class VecBase(BaseModel):
     attributes: Attributes = Field(default_factory=dict)
-    name: StrictStr = Field(
-        ...,
-        description="This is a string encoding the name of this object data."
-        + " It is used as index inside the corresponding object data pointers.",
-    )
     type: Optional[TypeRange] = Field(
         None,
         description="This attribute specifies whether the vector shall be"
@@ -240,6 +255,18 @@ class Vec(BaseModel):
     coordinate_system: Optional[StrictStr] = Field(
         None,
         description="Name of the coordinate system in respect of which this object data is expressed.",
+    )
+
+    class Config:
+        use_enum_values = True
+        extra = Extra.allow
+
+
+class Vec(VecBase):
+    name: StrictStr = Field(
+        ...,
+        description="This is a string encoding the name of this object data."
+        + " It is used as index inside the corresponding object data pointers.",
     )
 
     class Config:
@@ -400,6 +427,10 @@ class ObjectData(BaseElementData):
         None,
         description='List of "matrix" that describe this object matrix information such as `confidence_score`.',
     )
+    binary: Optional[List[Binary]] = Field(
+        None,
+        description='List of "binary" that describe this object semantic mask info.',
+    )
 
 
 class ObjectUnderFrame(BaseModel):
@@ -536,6 +567,16 @@ class CoordinateSystem(BaseModel):
         extra = Extra.allow
 
 
+class TagData(BaseModel):
+    vec: List[VecBase] = Field(default_factory=list)
+
+
+class Tag(BaseModel):
+    ontology_uid: StrictStr = Field(...)
+    type: StrictStr = Field(...)
+    tag_data: TagData = Field(...)
+
+
 class VisionAI(BaseModel):
     class Config:
         extra = Extra.forbid
@@ -571,6 +612,12 @@ class VisionAI(BaseModel):
     )
 
     metadata: Metadata = Field(default_factory=Metadata)
+
+    tags: Dict[StrictStr, Tag] = Field(
+        default_factory=dict,
+        description="This is the JSON object of tags. Object keys are strings."
+        + " Values are dictionary containing information of current sequence.",
+    )
 
 
 class VisionAIModel(BaseModel):


### PR DESCRIPTION
## Purpose

as mentioned, adding fields for new semantic segmentation format.
[AB#13126](https://dev.azure.com/linkerengineer/Dataverse/_sprints/taskboard/Dataverse%20Team/Dataverse/Sprint%2031%20-%20Pixel%20wise%20smantic%20segmetation?workitem=13126)
- defined [spec ](https://linkervision.getoutline.com/doc/tags-nsxeVqk0KP)

## What Changes?
- add `tags` under visionai
- add `binary` model for object related value
- update to newer version number



## What to Check?

it should work, could validate our sample [data](https://portal.azure.com/#view/Microsoft_Azure_Storage/ContainerMenuBlade/~/overview/storageAccountId/%2Fsubscriptions%2F091725d9-aeba-4638-8faf-d0e81a03a93d%2FresourceGroups%2Frg-observteam-dev-001%2Fproviders%2FMicrosoft.Storage%2FstorageAccounts%2Fhelenmlopsstorageqatest/path/vainewformat/etag/%220x8DACEB6E744A51D%22/defaultEncryptionScope/%24account-encryption-key/denyEncryptionScopeOverride~/false/defaultId//publicAccessVal/Container)
