### PR TITLE
fix(python): fix save json indent

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "visionai-data-format"
-PACKAGE_VERSION = "0.1.8"
+PACKAGE_VERSION = "0.1.9"
 DESC = "converter tool for visionai format"
 REQUIRED = ["pydantic"]
 REQUIRES_PYTHON = ">=3.7, <4"

--- a/visionai_data_format/utils/validator.py
+++ b/visionai_data_format/utils/validator.py
@@ -56,7 +56,7 @@ def save_as_json(data: dict, file_name: str, folder_name: str = "") -> None:
         logger.info(
             f"[save_as_json] Save file to {os.path.join(folder_name,file_name)} started "
         )
-        json.dump(data, file, indent=4)
+        json.dump(data, file)
         logger.info(
             f"[save_as_json] Save file to {os.path.join(folder_name,file_name)} success"
         )


### PR DESCRIPTION
## Purpose
- Remove indent since the output objects.json is too large
