### PR TITLE
fix(python): update visionai fields default value

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,30 @@
+import json
+import os
+
+import pytest
+
+TEST_DATA_FOLDER = "tests/test_data"
+
+
+@pytest.fixture(scope="session")
+def fake_raw_visionai_data():
+    file_name = "fake_raw_data.json"
+    return json.load(open(os.path.join(TEST_DATA_FOLDER, file_name)))
+
+
+@pytest.fixture(scope="session")
+def fake_generated_raw_visionai_data():
+    file_name = "generated_raw_data.json"
+    return json.load(open(os.path.join(TEST_DATA_FOLDER, file_name)))
+
+
+@pytest.fixture(scope="session")
+def fake_objects_visionai_data():
+    file_name = "fake_objects_data.json"
+    return json.load(open(os.path.join(TEST_DATA_FOLDER, file_name)))
+
+
+@pytest.fixture(scope="session")
+def fake_generated_objects_visionai_data():
+    file_name = "generated_objects_data.json"
+    return json.load(open(os.path.join(TEST_DATA_FOLDER, file_name)))

--- a/tests/test_data/fake_objects_data.json
+++ b/tests/test_data/fake_objects_data.json
@@ -1,0 +1,224 @@
+{
+    "visionai": {
+        "frame_intervals": [
+            {
+                "frame_start": 0,
+                "frame_end": 0
+            }
+        ],
+        "frames": {
+            "000000000000": {
+                "objects": {
+                    "893ac389-7782-4bc3-8f61-09a8e48c819f": {
+                        "object_data": {
+                            "bbox": [
+                                {
+                                    "name": "bbox_shape",
+                                    "stream": "camera1",
+                                    "coordinate_system": "camera1",
+                                    "val": [
+                                        761.565,
+                                        225.46,
+                                        98.33000000000004,
+                                        164.92000000000002
+                                    ]
+                                }
+                            ],
+                            "cuboid": [
+                                {
+                                    "name": "cuboid_shape",
+                                    "stream": "lidar1",
+                                    "coordinate_system": "lidar1",
+                                    "val": [
+                                        8.727633224700037,
+                                        -1.8557590122690717,
+                                        -0.6544039394148177,
+                                        0.0,
+                                        0.0,
+                                        -1.5807963267948966,
+                                        1.2,
+                                        0.48,
+                                        1.89
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+                "frame_properties": {
+                    "timestamp": "2020-04-11T12:00:01.000+0100",
+                    "streams": {
+                        "camera1": {
+                            "uri": "https://image1.path.url.png",
+                            "stream_properties": {
+                                "sync": {
+                                    "timestamp": "2020-04-11T12:00:07.010+0100"
+                                }
+                            }
+                        },
+                        "lidar1": {
+                            "uri": "https://lidar0.path.url.pcd",
+                            "stream_properties": {
+                                "sync": {
+                                    "timestamp": "2020-04-11T12:00:10.087-01:00"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "streams": {
+            "camera1": {
+                "type": "camera"
+            }
+        },
+        "coordinate_systems": {
+            "iso8855-1": {
+                "type": "local_cs",
+                "parent": "",
+                "children": [
+                    "lidar1",
+                    "lidar2"
+                ]
+            },
+            "lidar1": {
+                "type": "sensor_cs",
+                "parent": "iso8855-1",
+                "children": [
+                    "camera1"
+                ],
+                "pose_wrt_parent": {
+                    "matrix4x4": [
+                        0.984807753012208,
+                        0.0,
+                        0.17364817766693033,
+                        2.3,
+                        0.0,
+                        1.0,
+                        0.0,
+                        0.0,
+                        -0.17364817766693033,
+                        0.0,
+                        0.984807753012208,
+                        1.3,
+                        0.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ]
+                }
+            },
+            "lidar2": {
+                "type": "sensor_cs",
+                "parent": "iso8855-1",
+                "children": [
+                    "camera2"
+                ],
+                "pose_wrt_parent": {
+                    "matrix4x4": [
+                        0.984807753012208,
+                        0.0,
+                        0.17364817766693033,
+                        2.3,
+                        0.0,
+                        1.0,
+                        0.0,
+                        0.0,
+                        -0.17364817766693033,
+                        0.0,
+                        0.984807753012208,
+                        1.3,
+                        0.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ]
+                }
+            },
+            "camera1": {
+                "type": "sensor_cs",
+                "parent": "lidar1",
+                "children": [],
+                "pose_wrt_parent": {
+                    "matrix4x4": [
+                        0.984807753012208,
+                        0.0,
+                        0.17364817766693033,
+                        2.3,
+                        0.0,
+                        1.0,
+                        0.0,
+                        0.0,
+                        -0.17364817766693033,
+                        0.0,
+                        0.984807753012208,
+                        1.3,
+                        0.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ]
+                }
+            },
+            "camera2": {
+                "type": "sensor_cs",
+                "parent": "lidar2",
+                "children": [],
+                "pose_wrt_parent": {
+                    "matrix4x4": [
+                        0.984807753012208,
+                        0.0,
+                        0.17364817766693033,
+                        2.3,
+                        0.0,
+                        1.0,
+                        0.0,
+                        0.0,
+                        -0.17364817766693033,
+                        0.0,
+                        0.984807753012208,
+                        1.3,
+                        0.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ]
+                }
+            }
+        },
+        "objects": {
+            "893ac389-7782-4bc3-8f61-09a8e48c819f": {
+                "frame_intervals": [
+                    {
+                        "frame_start": 0,
+                        "frame_end": 0
+                    }
+                ],
+                "name": "pedestrian",
+                "object_data": {},
+                "object_data_pointers": {
+                    "bbox_shape": {
+                        "frame_intervals": [
+                            {
+                                "frame_start": 0,
+                                "frame_end": 0
+                            }
+                        ],
+                        "type": "bbox"
+                    },
+                    "cuboid_shape": {
+                        "frame_intervals": [
+                            {
+                                "frame_start": 0,
+                                "frame_end": 0
+                            }
+                        ],
+                        "type": "cuboid"
+                    }
+                },
+                "type": "pedestrian"
+            }
+        }
+    }
+}

--- a/tests/test_data/fake_objects_data.json
+++ b/tests/test_data/fake_objects_data.json
@@ -219,6 +219,9 @@
                 },
                 "type": "pedestrian"
             }
+        },
+        "metadata":{
+            "schema_version":"1.0.0"
         }
     }
 }

--- a/tests/test_data/fake_raw_data.json
+++ b/tests/test_data/fake_raw_data.json
@@ -1,0 +1,154 @@
+{
+    "visionai": {
+        "frame_intervals": [
+            {
+                "frame_start": 0,
+                "frame_end": 0
+            }
+        ],
+        "frames": {
+            "000000000000": {
+                "frame_properties": {
+                    "timestamp": "2020-04-11T12:00:01.000+0100",
+                    "streams": {
+                        "camera1": {
+                            "uri": "https://image1.path.url.png",
+                            "stream_properties": {
+                                "sync": {
+                                    "timestamp": "2020-04-11T12:00:07.010+0100"
+                                }
+                            }
+                        },
+                        "lidar1": {
+                            "uri": "https://lidar0.path.url.pcd",
+                            "stream_properties": {
+                                "sync": {
+                                    "timestamp": "2020-04-11T12:00:10.087-01:00"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "coordinate_systems": {
+            "iso8855-1": {
+                "type": "local_cs",
+                "parent": "",
+                "children": [
+                    "lidar1",
+                    "lidar2"
+                ]
+            },
+            "lidar1": {
+                "type": "sensor_cs",
+                "parent": "iso8855-1",
+                "children": [
+                    "camera1"
+                ],
+                "pose_wrt_parent": {
+                    "matrix4x4": [
+                        0.984807753012208,
+                        0.0,
+                        0.17364817766693033,
+                        2.3,
+                        0.0,
+                        1.0,
+                        0.0,
+                        0.0,
+                        -0.17364817766693033,
+                        0.0,
+                        0.984807753012208,
+                        1.3,
+                        0.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ]
+                }
+            },
+            "lidar2": {
+                "type": "sensor_cs",
+                "parent": "iso8855-1",
+                "children": [
+                    "camera2"
+                ],
+                "pose_wrt_parent": {
+                    "matrix4x4": [
+                        0.984807753012208,
+                        0.0,
+                        0.17364817766693033,
+                        2.3,
+                        0.0,
+                        1.0,
+                        0.0,
+                        0.0,
+                        -0.17364817766693033,
+                        0.0,
+                        0.984807753012208,
+                        1.3,
+                        0.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ]
+                }
+            },
+            "camera1": {
+                "type": "sensor_cs",
+                "parent": "lidar1",
+                "children": [],
+                "pose_wrt_parent": {
+                    "matrix4x4": [
+                        0.984807753012208,
+                        0.0,
+                        0.17364817766693033,
+                        2.3,
+                        0.0,
+                        1.0,
+                        0.0,
+                        0.0,
+                        -0.17364817766693033,
+                        0.0,
+                        0.984807753012208,
+                        1.3,
+                        0.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ]
+                }
+            },
+            "camera2": {
+                "type": "sensor_cs",
+                "parent": "lidar2",
+                "children": [],
+                "pose_wrt_parent": {
+                    "matrix4x4": [
+                        0.984807753012208,
+                        0.0,
+                        0.17364817766693033,
+                        2.3,
+                        0.0,
+                        1.0,
+                        0.0,
+                        0.0,
+                        -0.17364817766693033,
+                        0.0,
+                        0.984807753012208,
+                        1.3,
+                        0.0,
+                        0.0,
+                        0.0,
+                        1.0
+                    ]
+                }
+            }
+        },
+        "streams": {
+            "camera1": {
+                "type": "camera"
+            }
+        }
+    }
+}

--- a/tests/test_data/fake_raw_data.json
+++ b/tests/test_data/fake_raw_data.json
@@ -149,6 +149,9 @@
             "camera1": {
                 "type": "camera"
             }
+        },
+        "metadata":{
+            "schema_version":"1.0.0"
         }
     }
 }

--- a/tests/test_data/generated_objects_data.json
+++ b/tests/test_data/generated_objects_data.json
@@ -1,0 +1,224 @@
+{
+    "visionai": {
+        "frame_intervals": [
+            {
+                "frame_start": 0,
+                "frame_end": 0
+            }
+        ],
+        "frames": {
+            "000000000000": {
+                "objects": {
+                    "893ac389-7782-4bc3-8f61-09a8e48c819f": {
+                        "object_data": {
+                            "bbox": [
+                                {
+                                    "name": "bbox_shape",
+                                    "stream": "camera1",
+                                    "coordinate_system": "camera1",
+                                    "val": [
+                                        761.565,
+                                        225.46,
+                                        98.33000000000004,
+                                        164.92000000000002
+                                    ]
+                                }
+                            ],
+                            "cuboid": [
+                                {
+                                    "name": "cuboid_shape",
+                                    "stream": "lidar1",
+                                    "coordinate_system": "lidar1",
+                                    "val": [
+                                        8.727633224700037,
+                                        -1.8557590122690717,
+                                        -0.6544039394148177,
+                                        0.0,
+                                        0.0,
+                                        -1.5807963267948966,
+                                        1.2,
+                                        0.48,
+                                        1.89
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+                "frame_properties": {
+                    "timestamp": "2020-04-11T12:00:01.000+0100",
+                    "streams": {
+                        "camera1": {
+                            "uri": "https://image1.path.url.png",
+                            "stream_properties": {
+                                "sync": {
+                                    "timestamp": "2020-04-11T12:00:07.010+0100"
+                                }
+                            }
+                        },
+                        "lidar1": {
+                            "uri": "https://lidar0.path.url.pcd",
+                            "stream_properties": {
+                                "sync": {
+                                    "timestamp": "2020-04-11T12:00:10.087-01:00"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "objects": {
+            "893ac389-7782-4bc3-8f61-09a8e48c819f": {
+                "frame_intervals": [
+                    {
+                        "frame_start": 0,
+                        "frame_end": 0
+                    }
+                ],
+                "name": "pedestrian",
+                "object_data": {},
+                "object_data_pointers": {
+                    "bbox_shape": {
+                        "frame_intervals": [
+                            {
+                                "frame_start": 0,
+                                "frame_end": 0
+                            }
+                        ],
+                        "type": "bbox"
+                    },
+                    "cuboid_shape": {
+                        "frame_intervals": [
+                            {
+                                "frame_start": 0,
+                                "frame_end": 0
+                            }
+                        ],
+                        "type": "cuboid"
+                    }
+                },
+                "type": "pedestrian"
+            }
+        },
+        "coordinate_systems": {
+            "iso8855-1": {
+                "type": "local_cs",
+                "parent": "",
+                "children": [
+                    "lidar1",
+                    "lidar2"
+                ]
+            },
+            "lidar1": {
+                "type": "sensor_cs",
+                "parent": "iso8855-1",
+                "children": [
+                    "camera1"
+                ],
+                "pose_wrt_parent": {
+                    "matrix4x4": [
+                        0,
+                        0,
+                        0,
+                        2,
+                        0,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                        0,
+                        1
+                    ]
+                }
+            },
+            "lidar2": {
+                "type": "sensor_cs",
+                "parent": "iso8855-1",
+                "children": [
+                    "camera2"
+                ],
+                "pose_wrt_parent": {
+                    "matrix4x4": [
+                        0,
+                        0,
+                        0,
+                        2,
+                        0,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                        0,
+                        1
+                    ]
+                }
+            },
+            "camera1": {
+                "type": "sensor_cs",
+                "parent": "lidar1",
+                "children": [],
+                "pose_wrt_parent": {
+                    "matrix4x4": [
+                        0,
+                        0,
+                        0,
+                        2,
+                        0,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                        0,
+                        1
+                    ]
+                }
+            },
+            "camera2": {
+                "type": "sensor_cs",
+                "parent": "lidar2",
+                "children": [],
+                "pose_wrt_parent": {
+                    "matrix4x4": [
+                        0,
+                        0,
+                        0,
+                        2,
+                        0,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                        0,
+                        1
+                    ]
+                }
+            }
+        },
+        "streams": {
+            "camera1": {
+                "type": "camera"
+            }
+        }
+    }
+}

--- a/tests/test_data/generated_objects_data.json
+++ b/tests/test_data/generated_objects_data.json
@@ -219,6 +219,9 @@
             "camera1": {
                 "type": "camera"
             }
+        },
+        "metadata":{
+            "schema_version":"1.0.0"
         }
     }
 }

--- a/tests/test_data/generated_raw_data.json
+++ b/tests/test_data/generated_raw_data.json
@@ -1,0 +1,154 @@
+{
+    "visionai": {
+        "frame_intervals": [
+            {
+                "frame_start": 0,
+                "frame_end": 0
+            }
+        ],
+        "frames": {
+            "000000000000": {
+                "frame_properties": {
+                    "timestamp": "2020-04-11T12:00:01.000+0100",
+                    "streams": {
+                        "camera1": {
+                            "uri": "https://image1.path.url.png",
+                            "stream_properties": {
+                                "sync": {
+                                    "timestamp": "2020-04-11T12:00:07.010+0100"
+                                }
+                            }
+                        },
+                        "lidar1": {
+                            "uri": "https://lidar0.path.url.pcd",
+                            "stream_properties": {
+                                "sync": {
+                                    "timestamp": "2020-04-11T12:00:10.087-01:00"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "coordinate_systems": {
+            "iso8855-1": {
+                "type": "local_cs",
+                "parent": "",
+                "children": [
+                    "lidar1",
+                    "lidar2"
+                ]
+            },
+            "lidar1": {
+                "type": "sensor_cs",
+                "parent": "iso8855-1",
+                "children": [
+                    "camera1"
+                ],
+                "pose_wrt_parent": {
+                    "matrix4x4": [
+                        0,
+                        0,
+                        0,
+                        2,
+                        0,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                        0,
+                        1
+                    ]
+                }
+            },
+            "lidar2": {
+                "type": "sensor_cs",
+                "parent": "iso8855-1",
+                "children": [
+                    "camera2"
+                ],
+                "pose_wrt_parent": {
+                    "matrix4x4": [
+                        0,
+                        0,
+                        0,
+                        2,
+                        0,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                        0,
+                        1
+                    ]
+                }
+            },
+            "camera1": {
+                "type": "sensor_cs",
+                "parent": "lidar1",
+                "children": [],
+                "pose_wrt_parent": {
+                    "matrix4x4": [
+                        0,
+                        0,
+                        0,
+                        2,
+                        0,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                        0,
+                        1
+                    ]
+                }
+            },
+            "camera2": {
+                "type": "sensor_cs",
+                "parent": "lidar2",
+                "children": [],
+                "pose_wrt_parent": {
+                    "matrix4x4": [
+                        0,
+                        0,
+                        0,
+                        2,
+                        0,
+                        1,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        1,
+                        0,
+                        0,
+                        0,
+                        1
+                    ]
+                }
+            }
+        },
+        "streams": {
+            "camera1": {
+                "type": "camera"
+            }
+        }
+    }
+}

--- a/tests/test_data/generated_raw_data.json
+++ b/tests/test_data/generated_raw_data.json
@@ -149,6 +149,9 @@
             "camera1": {
                 "type": "camera"
             }
+        },
+        "metadata":{
+            "schema_version":"1.0.0"
         }
     }
 }

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,6 +1,8 @@
+import pytest
+
 from visionai_data_format.schemas.bdd_schema import BDDSchema
 from visionai_data_format.schemas.coco_schema import Coco
-from visionai_data_format.schemas.visionai_schema import VisionAI, VisionAIModel
+from visionai_data_format.schemas.visionai_schema import VisionAIModel
 
 
 def test_coco():
@@ -51,32 +53,26 @@ def test_visionai_model():
             "metadata": {"schema_version": "1.0.0"},
         }
     }
+    with pytest.raises(Exception):
+        assert VisionAIModel(**input_data).dict() == generated_data
 
-    assert VisionAIModel(**input_data).dict() == generated_data
 
+def test_visionai(
+    fake_raw_visionai_data,
+    fake_generated_raw_visionai_data,
+    fake_objects_visionai_data,
+    fake_generated_objects_visionai_data,
+):
 
-def test_visionai():
-    input_data = {
-        "contexts": {},
-        "frame_intervals": [],
-        "frames": {},
-        "objects": {},
-        "coordinate_systems": {},
-        "streams": {},
-        "tags": {},
-    }
-    generated_data = {
-        "contexts": {},
-        "frame_intervals": [],
-        "frames": {},
-        "objects": {},
-        "coordinate_systems": {},
-        "streams": {},
-        "tags": {},
-        "metadata": {"schema_version": "1.0.0"},
-    }
+    assert (
+        VisionAIModel(**fake_raw_visionai_data).dict(exclude_unset=True)
+        == fake_generated_raw_visionai_data
+    )
 
-    assert VisionAI(**input_data).dict() == generated_data
+    assert (
+        VisionAIModel(**fake_objects_visionai_data).dict(exclude_unset=True)
+        == fake_generated_objects_visionai_data
+    )
 
 
 def test_bdd():

--- a/visionai_data_format/schemas/visionai_schema.py
+++ b/visionai_data_format/schemas/visionai_schema.py
@@ -430,7 +430,7 @@ class Metadata(BaseModel):
         extra = Extra.allow
 
     schema_version: SchemaVersion = Field(
-        default=SchemaVersion.field_1_0_0,
+        default=...,
         description="Version number of the VisionAI schema this annotation JSON object follows.",
     )
 
@@ -694,7 +694,7 @@ class VisionAI(BaseModel):
         description="This is the JSON object of VisionAI that contains the streams and their details.",
     )
 
-    metadata: Optional[Metadata] = Field(default_factory=Metadata)
+    metadata: Metadata = Field(default=...)
 
     tags: Optional[Dict[StrictStr, Tag]] = Field(
         default=None,

--- a/visionai_data_format/schemas/visionai_schema.py
+++ b/visionai_data_format/schemas/visionai_schema.py
@@ -489,9 +489,6 @@ class TimeStampElement(BaseModel):
 class StreamPropertyUnderFrameProperty(BaseModel):
     sync: TimeStampElement
 
-    class Config:
-        extra = Extra.allow
-
 
 class FramePropertyStream(BaseModel):
     uri: str = Field(..., description="the urls of image")
@@ -659,6 +656,16 @@ class VisionAI(BaseModel):
         description="This is the JSON object of frames that contain the dynamic, time-wise, annotations."
         + " Keys are strings containing numerical frame identifiers, which are denoted as master frame numbers.",
     )
+
+    @validator("frames")
+    def validate_frames(cls, value):
+        frame_keys = list(value.keys())
+
+        assert all(
+            len(key) == 12 and key.isdigit() for key in frame_keys
+        ), "Key must be a digit with 12 characters length"
+
+        return value
 
     objects: Optional[Dict[StrictStr, Object]] = Field(
         default=None,


### PR DESCRIPTION
## Purpose

modify default values of visionai fields except of `objects` and `contexts` related fields.

[AB#13467](https://dev.azure.com/linkerengineer/Dataverse/_sprints/taskboard/Dataverse%20Team/Dataverse/Sprint%2033%20-%20VisionAI%20Fomat%20Refinement?workitem=13467)

## What Changes?

- change fields default value
- adding validation for fields
- modify test behaviour

Mainly changes `visionai_data_format/schemas/visionai_schema.py`, `tests/test_schemas.py`, and `conftest.py` files.

## What to Check?

it should work. Will be merged to `feat/refactor-visionai-schema`, since we will update `contexts` and `objects` related in the next PR