### PR TITLE
feat(python): update contexts and objects schema

### DIFF
--- a/tests/test_data/fake_objects_data.json
+++ b/tests/test_data/fake_objects_data.json
@@ -196,7 +196,6 @@
                     }
                 ],
                 "name": "pedestrian",
-                "object_data": {},
                 "object_data_pointers": {
                     "bbox_shape": {
                         "frame_intervals": [

--- a/tests/test_data/generated_objects_data.json
+++ b/tests/test_data/generated_objects_data.json
@@ -77,7 +77,6 @@
                     }
                 ],
                 "name": "pedestrian",
-                "object_data": {},
                 "object_data_pointers": {
                     "bbox_shape": {
                         "frame_intervals": [

--- a/visionai_data_format/schemas/visionai_schema.py
+++ b/visionai_data_format/schemas/visionai_schema.py
@@ -93,10 +93,6 @@ class ObjectDataElement(BaseModel):
     stream: StrictStr = Field(
         description="Name of the stream in respect of which this object data is expressed.",
     )
-    coordinate_system: Optional[StrictStr] = Field(
-        None,
-        description="Name of the coordinate system in respect of which this object data is expressed.",
-    )
     confidence_score: Optional[float] = Field(
         None,
         description="The confidence score of model prediction of this object."

--- a/visionai_data_format/schemas/visionai_schema.py
+++ b/visionai_data_format/schemas/visionai_schema.py
@@ -398,42 +398,34 @@ class Context(BaseModel):
 
     @root_validator
     def validate_context_data_relations(cls, values):
-        context_data_pointer = values.get("context_data_pointers")
+        context_data_pointers = values.get("context_data_pointers")
         context_data = values.get("context_data", {})
-        if context_data and not context_data_pointer:
+        if context_data and not context_data_pointers:
             raise ValueError(
-                "context data pointers can't be empty with context data exists"
+                "context data pointers can't be empty with contexts data exists"
             )
 
-        if not context_data or not context_data_pointer:
+        if not context_data or not context_data_pointers:
             return values
 
-        static_context_data_name_type_map = {}
-        context_data = dict(context_data)
-        for obj_type, obj_info_list in context_data.items():
+        static_contexts_data_name_type_map = {}
+        for obj_type, obj_info_list in context_data:
             if not obj_info_list:
                 continue
             for obj_info in obj_info_list:
-                static_context_data_name_type_map.update({obj_info.name: obj_type})
-        for obj_name, obj_type in static_context_data_name_type_map.items():
-            # dynamic attribute context data pointers must contain frame intervals
-            obj_data_dict = dict(context_data_pointer.get(obj_name, {}))
+                static_contexts_data_name_type_map.update({obj_info.name: obj_type})
+        for obj_name, obj_type in static_contexts_data_name_type_map.items():
+            obj_data_dict = context_data_pointers.get(obj_name, {})
             if not obj_data_dict:
                 raise ValueError(
-                    f"Static context data {obj_name}:{obj_type} doesn't found under context data pointer"
+                    f"Static contexts data {obj_name}:{obj_type} doesn't found under context data pointer"
                 )
-            if not obj_data_dict.get("frame_intervals"):
+            obj_data_pointer_type = getattr(obj_data_dict, "type", "")
+            if obj_type != obj_data_pointer_type:
                 raise ValueError(
-                    f"Static context data pointer {obj_name}"
-                    + " missing frame intervals"
+                    f"Static contexts data {obj_name}:{obj_type} doesn't match"
+                    + f" with data_pointer {obj_name}:{obj_data_pointer_type}"
                 )
-            obj_data_pointer_type = obj_data_dict.get("type")
-            if obj_type == obj_data_pointer_type:
-                continue
-            raise ValueError(
-                f"Static context data {obj_name}:{obj_type} doesn't match"
-                + f" with data_pointer {obj_name}:{obj_data_pointer_type}"
-            )
 
         return values
 
@@ -660,42 +652,34 @@ class Object(BaseModel):
 
     @root_validator
     def validate_object_data_relations(cls, values):
-        object_data_pointer = values.get("object_data_pointers")
+        object_data_pointers = values.get("object_data_pointers")
         object_data = values.get("object_data", {})
-        if object_data and not object_data_pointer:
+        if object_data and not object_data_pointers:
             raise ValueError(
-                "object data pointers can't be empty with object data exists"
+                "object data pointers can't be empty with objects data exists"
             )
 
-        if not object_data or not object_data_pointer:
+        if not object_data or not object_data_pointers:
             return values
 
-        static_object_data_name_type_map = {}
-        object_data = dict(object_data)
-        for obj_type, obj_info_list in object_data.items():
+        static_objects_data_name_type_map = {}
+        for obj_type, obj_info_list in object_data:
             if not obj_info_list:
                 continue
             for obj_info in obj_info_list:
-                static_object_data_name_type_map.update({obj_info.name: obj_type})
-        for obj_name, obj_type in static_object_data_name_type_map.items():
-            # dynamic attribute object data pointers must contain frame intervals
-            obj_data_dict = dict(object_data_pointer.get(obj_name, {}))
+                static_objects_data_name_type_map.update({obj_info.name: obj_type})
+        for obj_name, obj_type in static_objects_data_name_type_map.items():
+            obj_data_dict = object_data_pointers.get(obj_name, {})
             if not obj_data_dict:
                 raise ValueError(
-                    f"Static object data {obj_name}:{obj_type} doesn't found under object data pointer"
+                    f"Static object data {obj_name}:{obj_type} doesn't found under objects data pointer"
                 )
-            if not obj_data_dict.get("frame_intervals"):
+            obj_data_pointer_type = getattr(obj_data_dict, "type", "")
+            if obj_type != obj_data_pointer_type:
                 raise ValueError(
-                    f"Static object data pointer {obj_name}"
-                    + " missing frame intervals"
+                    f"Static object data {obj_name}:{obj_type} doesn't match"
+                    + f" with data_pointer {obj_name}:{obj_data_pointer_type}"
                 )
-            obj_data_pointer_type = obj_data_dict.get("type")
-            if obj_type == obj_data_pointer_type:
-                continue
-            raise ValueError(
-                f"Static object data {obj_name}:{obj_type} doesn't match"
-                + f" with data_pointer {obj_name}:{obj_data_pointer_type}"
-            )
 
         return values
 

--- a/visionai_data_format/schemas/visionai_schema.py
+++ b/visionai_data_format/schemas/visionai_schema.py
@@ -402,7 +402,6 @@ class Context(BaseModel):
 
     @root_validator
     def validate_context_data_relations(cls, values):
-        print(values)
         context_data_pointer = values.get("context_data_pointers")
         context_data = values.get("context_data", {})
         if context_data and not context_data_pointer:

--- a/visionai_data_format/schemas/visionai_schema.py
+++ b/visionai_data_format/schemas/visionai_schema.py
@@ -384,7 +384,7 @@ class Context(BaseModel):
         description="Name of the context. It is a friendly name and not used for indexing.",
     )
     context_data: Optional[ContextData] = None
-    context_data_pointers: Optional[Dict[StrictStr, ContextDataPointer]] = None
+    context_data_pointers: Dict[StrictStr, ContextDataPointer]
     type: StrictStr = Field(
         ...,
         description="The type of a context, defines the class the context corresponds to.",
@@ -647,7 +647,7 @@ class Object(BaseModel):
         description="Name of the object. It is a friendly name and not used for indexing.",
     )
     object_data: Optional[ObjectDataStatic] = None
-    object_data_pointers: Optional[Dict[StrictStr, ObjectDataPointer]] = None
+    object_data_pointers: Dict[StrictStr, ObjectDataPointer]
     type: StrictStr = Field(
         ...,
         description="The type of an object, defines the class the object corresponds to.",


### PR DESCRIPTION
## Purpose
update contexts and objects schema required fields and validation logic.[AB#13588](https://dev.azure.com/linkerengineer/Dataverse/_sprints/taskboard/Dataverse%20Team/Dataverse/Sprint%2033%20-%20VisionAI%20Fomat%20Refinement?workitem=13588)

## What Changes?

- change required fields condition based on newest format version
- add data pointer with data relationship validation
- separate allowed object type in static and dynamic attributes ( `static` attribute can't contains `bbox`, `cuboid`,`poly2d`,`point2d`, and `binary`)
- remove `coordinate_systems` from `objects` under `frames`

## What to Check?

it should work

- object_data_pointer empty dict will raise error
![image](https://user-images.githubusercontent.com/94961931/233025512-196a1a0d-c6a2-451b-a6ca-138f9da185f2.png)

![image](https://user-images.githubusercontent.com/94961931/233025547-48af3fd7-d0e9-4055-b27d-3f76ba088718.png)

- context_data/object_data empty dict will raise error
![image](https://user-images.githubusercontent.com/94961931/233026478-19795a34-6adc-4087-bb80-f19af8dbf145.png)

![image](https://user-images.githubusercontent.com/94961931/233026564-98d3ba6a-da3c-4883-a01b-fb8d6a9f7a27.png)

- object_data_pointer missing static object_data information will raise error
![image](https://user-images.githubusercontent.com/94961931/233028041-727f6154-75dc-4cf1-b040-f69cc0d40ec7.png)

![image](https://user-images.githubusercontent.com/94961931/233026247-be0804b0-0074-401c-a462-e9a2b22f74c4.png)


- raise error if context/object data pointer for dynamic attributes missing frame intervals 
frame intervals in dynamic object_data is required 
<img width="834" alt="image" src="https://user-images.githubusercontent.com/94961931/233248079-f2c15b4d-9b0f-492f-a102-1b01a70a93b9.png">

![image](https://user-images.githubusercontent.com/94961931/233247841-bf6988e5-a14e-418c-b4ce-76a14f1e84c0.png)




