### PR TITLE
fix(python): modify visionai schema structure

### DIFF
--- a/tests/test_data/fake_objects_data.json
+++ b/tests/test_data/fake_objects_data.json
@@ -15,7 +15,6 @@
                                 {
                                     "name": "bbox_shape",
                                     "stream": "camera1",
-                                    "coordinate_system": "camera1",
                                     "val": [
                                         761.565,
                                         225.46,
@@ -28,7 +27,6 @@
                                 {
                                     "name": "cuboid_shape",
                                     "stream": "lidar1",
-                                    "coordinate_system": "lidar1",
                                     "val": [
                                         8.727633224700037,
                                         -1.8557590122690717,

--- a/tests/test_data/generated_objects_data.json
+++ b/tests/test_data/generated_objects_data.json
@@ -15,7 +15,6 @@
                                 {
                                     "name": "bbox_shape",
                                     "stream": "camera1",
-                                    "coordinate_system": "camera1",
                                     "val": [
                                         761.565,
                                         225.46,
@@ -28,7 +27,6 @@
                                 {
                                     "name": "cuboid_shape",
                                     "stream": "lidar1",
-                                    "coordinate_system": "lidar1",
                                     "val": [
                                         8.727633224700037,
                                         -1.8557590122690717,

--- a/visionai_data_format/coco_to_vai.py
+++ b/visionai_data_format/coco_to_vai.py
@@ -13,7 +13,7 @@ from visionai_data_format.schemas.visionai_schema import (
     FramePropertyStream,
     Metadata,
     Object,
-    ObjectData,
+    ObjectDataDynamic,
     ObjectDataPointer,
     ObjectType,
     ObjectUnderFrame,
@@ -109,13 +109,12 @@ def _coco_to_vision_ai(
         # assume there is only one sensor, so image_index always is 0
         objects_under_frames = {
             object_id: ObjectUnderFrame(
-                object_data=ObjectData(
+                object_data=ObjectDataDynamic(
                     bbox=[
                         Bbox(
                             name=BBOX_NAME,
                             val=bbox,
                             stream=sensor_name,
-                            coordinate_system=sensor_name,
                         )
                     ]
                 )

--- a/visionai_data_format/coco_to_vai.py
+++ b/visionai_data_format/coco_to_vai.py
@@ -7,13 +7,13 @@ import uuid
 
 from visionai_data_format.schemas.visionai_schema import (
     Bbox,
+    DynamicObjectData,
     Frame,
     FrameInterval,
     FrameProperties,
     FramePropertyStream,
     Metadata,
     Object,
-    ObjectDataDynamic,
     ObjectDataPointer,
     ObjectType,
     ObjectUnderFrame,
@@ -109,7 +109,7 @@ def _coco_to_vision_ai(
         # assume there is only one sensor, so image_index always is 0
         objects_under_frames = {
             object_id: ObjectUnderFrame(
-                object_data=ObjectDataDynamic(
+                object_data=DynamicObjectData(
                     bbox=[
                         Bbox(
                             name=BBOX_NAME,

--- a/visionai_data_format/schemas/visionai_schema.py
+++ b/visionai_data_format/schemas/visionai_schema.py
@@ -80,10 +80,10 @@ class Attributes(BaseModel):
     class Config:
         extra = Extra.forbid
 
-    boolean: List[BooleanBase] = Field(default_factory=list)
-    num: List[NumBase] = Field(default_factory=list)
-    text: List[TextBase] = Field(default_factory=list)
-    vec: List[VecBase] = Field(default_factory=list)
+    boolean: List[BooleanStatic] = Field(default_factory=list)
+    num: List[NumStatic] = Field(default_factory=list)
+    text: List[TextStatic] = Field(default_factory=list)
+    vec: List[VecStatic] = Field(default_factory=list)
 
 
 class CoordinateSystemWRTParent(BaseModel):
@@ -166,7 +166,7 @@ class Metadata(BaseModel):
     )
 
 
-class BooleanBase(BaseModel):
+class BooleanStatic(BaseModel):
 
     attributes: Optional[Attributes] = None
     name: StrictStr = Field(
@@ -186,18 +186,14 @@ class BooleanBase(BaseModel):
         extra = Extra.forbid
 
 
-class BooleanStaticAttr(BooleanBase):
-    pass
-
-
-class BooleanDynamicAttr(BooleanBase):
+class BooleanDynamic(BooleanStatic):
     stream: StrictStr = Field(
         ...,
         description="Name of the stream in respect of which this object data is expressed.",
     )
 
 
-class NumBase(BaseModel):
+class NumStatic(BaseModel):
     class Config:
         use_enum_values = True
         extra = Extra.forbid
@@ -218,18 +214,14 @@ class NumBase(BaseModel):
     )
 
 
-class NumStaticAttr(NumBase):
-    pass
-
-
-class NumDynamicAttr(NumBase):
+class NumDynamic(NumStatic):
     stream: StrictStr = Field(
         ...,
         description="Name of the stream in respect of which this object data is expressed.",
     )
 
 
-class TextBase(BaseModel):
+class TextStatic(BaseModel):
     class Config:
         use_enum_values = True
         extra = Extra.forbid
@@ -248,11 +240,7 @@ class TextBase(BaseModel):
     val: StrictStr = Field(..., description="The characters of the text.")
 
 
-class TextStaticAttr(TextBase):
-    pass
-
-
-class TextDynamicAttr(TextBase):
+class TextDynamic(TextStatic):
     stream: StrictStr = Field(
         ...,
         description="Name of the stream in respect of which this object data is expressed.",
@@ -275,7 +263,7 @@ class VecBaseNoName(BaseModel):
         extra = Extra.forbid
 
 
-class VecBase(VecBaseNoName):
+class VecStatic(VecBaseNoName):
     name: StrictStr = Field(
         ...,
         description="This is a string encoding the name of this object data."
@@ -283,11 +271,7 @@ class VecBase(VecBaseNoName):
     )
 
 
-class VecStaticAttr(VecBase):
-    pass
-
-
-class VecDynamicAttr(VecBase):
+class VecDynamic(VecStatic):
     stream: StrictStr = Field(
         ...,
         description="Name of the stream in respect of which this object data is expressed.",
@@ -296,32 +280,32 @@ class VecDynamicAttr(VecBase):
 
 class BaseStaticElementData(BaseModel):
 
-    boolean: Optional[List[BooleanStaticAttr]] = Field(
+    boolean: Optional[List[BooleanStatic]] = Field(
         None, description='List of "boolean" that describe this object.'
     )
-    num: Optional[List[NumStaticAttr]] = Field(
+    num: Optional[List[NumStatic]] = Field(
         None, description='List of "number" that describe this object.'
     )
-    text: Optional[List[TextStaticAttr]] = Field(
+    text: Optional[List[TextStatic]] = Field(
         None, description='List of "text" that describe this object.'
     )
-    vec: Optional[List[VecStaticAttr]] = Field(
+    vec: Optional[List[VecStatic]] = Field(
         None, description='List of "vec" that describe this object.'
     )
 
 
 class BaseDynamicElementData(BaseModel):
 
-    boolean: Optional[List[BooleanDynamicAttr]] = Field(
+    boolean: Optional[List[BooleanDynamic]] = Field(
         None, description='List of "boolean" that describe this object.'
     )
-    num: Optional[List[NumDynamicAttr]] = Field(
+    num: Optional[List[NumDynamic]] = Field(
         None, description='List of "number" that describe this object.'
     )
-    text: Optional[List[TextDynamicAttr]] = Field(
+    text: Optional[List[TextDynamic]] = Field(
         None, description='List of "text" that describe this object.'
     )
-    vec: Optional[List[VecDynamicAttr]] = Field(
+    vec: Optional[List[VecDynamic]] = Field(
         None, description='List of "vec" that describe this object.'
     )
 
@@ -531,7 +515,7 @@ class StreamProperties(BaseModel):
 
 
 class TagData(BaseModel):
-    vec: List[VecBase] = Field(...)
+    vec: List[VecStatic] = Field(...)
 
     @validator("vec")
     def validate_vec(cls, values):

--- a/visionai_data_format/schemas/visionai_schema.py
+++ b/visionai_data_format/schemas/visionai_schema.py
@@ -80,10 +80,10 @@ class Attributes(BaseModel):
     class Config:
         extra = Extra.forbid
 
-    boolean: List[BooleanStatic] = Field(default_factory=list)
-    num: List[NumStatic] = Field(default_factory=list)
-    text: List[TextStatic] = Field(default_factory=list)
-    vec: List[VecStatic] = Field(default_factory=list)
+    boolean: List[StaticBoolean] = Field(default_factory=list)
+    num: List[StaticNum] = Field(default_factory=list)
+    text: List[StaticText] = Field(default_factory=list)
+    vec: List[StaticVec] = Field(default_factory=list)
 
 
 class CoordinateSystemWRTParent(BaseModel):
@@ -166,7 +166,7 @@ class Metadata(BaseModel):
     )
 
 
-class BooleanStatic(BaseModel):
+class StaticBoolean(BaseModel):
 
     attributes: Optional[Attributes] = None
     name: StrictStr = Field(
@@ -186,14 +186,14 @@ class BooleanStatic(BaseModel):
         extra = Extra.forbid
 
 
-class BooleanDynamic(BooleanStatic):
+class DynamicBoolean(StaticBoolean):
     stream: StrictStr = Field(
         ...,
         description="Name of the stream in respect of which this object data is expressed.",
     )
 
 
-class NumStatic(BaseModel):
+class StaticNum(BaseModel):
     class Config:
         use_enum_values = True
         extra = Extra.forbid
@@ -214,14 +214,14 @@ class NumStatic(BaseModel):
     )
 
 
-class NumDynamic(NumStatic):
+class DynamicNum(StaticNum):
     stream: StrictStr = Field(
         ...,
         description="Name of the stream in respect of which this object data is expressed.",
     )
 
 
-class TextStatic(BaseModel):
+class StaticText(BaseModel):
     class Config:
         use_enum_values = True
         extra = Extra.forbid
@@ -240,7 +240,7 @@ class TextStatic(BaseModel):
     val: StrictStr = Field(..., description="The characters of the text.")
 
 
-class TextDynamic(TextStatic):
+class DynamicText(StaticText):
     stream: StrictStr = Field(
         ...,
         description="Name of the stream in respect of which this object data is expressed.",
@@ -263,7 +263,7 @@ class VecBaseNoName(BaseModel):
         extra = Extra.forbid
 
 
-class VecStatic(VecBaseNoName):
+class StaticVec(VecBaseNoName):
     name: StrictStr = Field(
         ...,
         description="This is a string encoding the name of this object data."
@@ -271,7 +271,7 @@ class VecStatic(VecBaseNoName):
     )
 
 
-class VecDynamic(VecStatic):
+class DynamicVec(StaticVec):
     stream: StrictStr = Field(
         ...,
         description="Name of the stream in respect of which this object data is expressed.",
@@ -280,32 +280,32 @@ class VecDynamic(VecStatic):
 
 class BaseStaticElementData(BaseModel):
 
-    boolean: Optional[List[BooleanStatic]] = Field(
+    boolean: Optional[List[StaticBoolean]] = Field(
         None, description='List of "boolean" that describe this object.'
     )
-    num: Optional[List[NumStatic]] = Field(
+    num: Optional[List[StaticNum]] = Field(
         None, description='List of "number" that describe this object.'
     )
-    text: Optional[List[TextStatic]] = Field(
+    text: Optional[List[StaticText]] = Field(
         None, description='List of "text" that describe this object.'
     )
-    vec: Optional[List[VecStatic]] = Field(
+    vec: Optional[List[StaticVec]] = Field(
         None, description='List of "vec" that describe this object.'
     )
 
 
 class BaseDynamicElementData(BaseModel):
 
-    boolean: Optional[List[BooleanDynamic]] = Field(
+    boolean: Optional[List[DynamicBoolean]] = Field(
         None, description='List of "boolean" that describe this object.'
     )
-    num: Optional[List[NumDynamic]] = Field(
+    num: Optional[List[DynamicNum]] = Field(
         None, description='List of "number" that describe this object.'
     )
-    text: Optional[List[TextDynamic]] = Field(
+    text: Optional[List[DynamicText]] = Field(
         None, description='List of "text" that describe this object.'
     )
-    vec: Optional[List[VecDynamic]] = Field(
+    vec: Optional[List[DynamicVec]] = Field(
         None, description='List of "vec" that describe this object.'
     )
 
@@ -329,7 +329,7 @@ class ContextDataStatic(BaseStaticElementData):
         extra = Extra.forbid
 
 
-class ContextDataDynamic(BaseDynamicElementData):
+class DynamicContextData(BaseDynamicElementData):
     class Config:
         extra = Extra.forbid
 
@@ -515,7 +515,7 @@ class StreamProperties(BaseModel):
 
 
 class TagData(BaseModel):
-    vec: List[VecStatic] = Field(...)
+    vec: List[StaticVec] = Field(...)
 
     @validator("vec")
     def validate_vec(cls, values):
@@ -678,7 +678,7 @@ class Binary(ObjectDataElement):
         return value
 
 
-class ObjectDataDynamic(BaseModel):
+class DynamicObjectData(BaseModel):
     class Config:
         extra = Extra.forbid
 
@@ -701,11 +701,11 @@ class ObjectDataDynamic(BaseModel):
 
 
 class ObjectUnderFrame(BaseModel):
-    object_data: ObjectDataDynamic
+    object_data: DynamicObjectData
 
 
 class ContextUnderFrame(BaseModel):
-    context_data: ContextDataDynamic
+    context_data: DynamicContextData
 
 
 class Frame(BaseModel):
@@ -824,6 +824,6 @@ ContextDataPointer.update_forward_refs()
 ContextUnderFrame.update_forward_refs()
 Frame.update_forward_refs()
 Object.update_forward_refs()
-ObjectDataDynamic.update_forward_refs()
+DynamicObjectData.update_forward_refs()
 ObjectUnderFrame.update_forward_refs()
 VisionAI.update_forward_refs()

--- a/visionai_data_format/utils/converter.py
+++ b/visionai_data_format/utils/converter.py
@@ -11,7 +11,7 @@ from visionai_data_format.schemas.visionai_schema import (
     FrameProperties,
     FramePropertyStream,
     Object,
-    ObjectData,
+    ObjectDataDynamic,
     ObjectDataPointer,
     ObjectType,
     ObjectUnderFrame,
@@ -122,7 +122,7 @@ def convert_bdd_to_vai(bdd_data: dict, vai_dest_folder: str, sensor_name: str) -
             frames: dict[str, Frame] = defaultdict(Frame)
             objects: dict[str, Object] = defaultdict(Object)
             frame_data: Frame = Frame(
-                objects=defaultdict(ObjectData),
+                objects=defaultdict(ObjectDataDynamic),
                 frame_properties=FrameProperties(
                     streams={sensor_name: FramePropertyStream(uri=url)}
                 ),
@@ -148,13 +148,12 @@ def convert_bdd_to_vai(bdd_data: dict, vai_dest_folder: str, sensor_name: str) -
                 confidence_score = label.get("meta_ds", {}).get("score", None)
                 object_under_frames = {
                     obj_uuid: ObjectUnderFrame(
-                        object_data=ObjectData(
+                        object_data=ObjectDataDynamic(
                             bbox=[
                                 Bbox(
                                     name="bbox_shape",
                                     val=[x, y, w, h],
                                     stream=sensor_name,
-                                    coordinate_system=sensor_name,
                                     confidence_score=confidence_score,
                                 )
                             ]
@@ -175,13 +174,6 @@ def convert_bdd_to_vai(bdd_data: dict, vai_dest_folder: str, sensor_name: str) -
                 )
             frames[frame_idx] = frame_data
             streams = {sensor_name: Stream(type=StreamType.camera)}
-            coordinate_systems = {
-                sensor_name: {
-                    "type": "sensor_cs",
-                    "parent": "vehicle-iso8855",
-                    "children": [],
-                }
-            }
             vai_data = {
                 "visionai": {
                     "frame_intervals": frame_intervals,
@@ -189,7 +181,6 @@ def convert_bdd_to_vai(bdd_data: dict, vai_dest_folder: str, sensor_name: str) -
                     "frames": frames,
                     "streams": streams,
                     "metadata": {"schema_version": "1.0.0"},
-                    "coordinate_systems": coordinate_systems,
                 }
             }
             vai_data = validate_vai(vai_data).dict(exclude_none=True)

--- a/visionai_data_format/utils/converter.py
+++ b/visionai_data_format/utils/converter.py
@@ -6,12 +6,12 @@ from collections import defaultdict
 from visionai_data_format.schemas.bdd_schema import AtrributeSchema
 from visionai_data_format.schemas.visionai_schema import (
     Bbox,
+    DynamicObjectData,
     Frame,
     FrameInterval,
     FrameProperties,
     FramePropertyStream,
     Object,
-    ObjectDataDynamic,
     ObjectDataPointer,
     ObjectType,
     ObjectUnderFrame,
@@ -122,7 +122,7 @@ def convert_bdd_to_vai(bdd_data: dict, vai_dest_folder: str, sensor_name: str) -
             frames: dict[str, Frame] = defaultdict(Frame)
             objects: dict[str, Object] = defaultdict(Object)
             frame_data: Frame = Frame(
-                objects=defaultdict(ObjectDataDynamic),
+                objects=defaultdict(DynamicObjectData),
                 frame_properties=FrameProperties(
                     streams={sensor_name: FramePropertyStream(uri=url)}
                 ),
@@ -148,7 +148,7 @@ def convert_bdd_to_vai(bdd_data: dict, vai_dest_folder: str, sensor_name: str) -
                 confidence_score = label.get("meta_ds", {}).get("score", None)
                 object_under_frames = {
                     obj_uuid: ObjectUnderFrame(
-                        object_data=ObjectDataDynamic(
+                        object_data=DynamicObjectData(
                             bbox=[
                                 Bbox(
                                     name="bbox_shape",


### PR DESCRIPTION
## Purpose

modify visionai schema to newer structure.

## What Changes?
- separate `object_data` and `context_data` with dynamic and static version. Only dynamic `object_data` and `context_data` should contains `stream` attribute
- remove `coordinate_system` from dynamic `object_data` and `context_data`.
- rename `number` with `num`
- relocate some basemodel

## What to Check?

- It should work.

