### PR TITLE
fix(python): fix wrong and missing visionai and ontology definition 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "visionai-data-format"
-PACKAGE_VERSION = "1.0.0"
+PACKAGE_VERSION = "1.0.1"
 DESC = "converter tool for visionai format"
 REQUIRED = ["pydantic"]
 REQUIRES_PYTHON = ">=3.7, <4"

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -57,7 +57,7 @@ def test_validate_bbox_wrong_class_under_visionai(
         ontology=ontology,
     )
 
-    assert errors == ["Label with classes {'children'} doesn't accepted"]
+    assert errors == ["Attribute objects with classes {'children'} doesn't accepted"]
 
 
 def test_validate_semantic_segmentation(

--- a/visionai_data_format/schemas/common.py
+++ b/visionai_data_format/schemas/common.py
@@ -49,7 +49,13 @@ class ExcludedNoneBaseModel(BaseModel):
     def dict(self, **kwargs):
         exclude_none = kwargs.pop("exclude_none", True)
         exclude_unset = kwargs.pop("exclude_unset", True)
-        data = super().dict(
+        return super().dict(
             exclude_none=exclude_none, exclude_unset=exclude_unset, **kwargs
         )
-        return data
+
+    def json(self, **kwargs):
+        exclude_none = kwargs.pop("exclude_none", True)
+        exclude_unset = kwargs.pop("exclude_unset", True)
+        return super().json(
+            exclude_none=exclude_none, exclude_unset=exclude_unset, **kwargs
+        )

--- a/visionai_data_format/schemas/common.py
+++ b/visionai_data_format/schemas/common.py
@@ -1,6 +1,8 @@
 from enum import Enum, EnumMeta
 from typing import Any, Optional, Set
 
+from pydantic import BaseModel
+
 
 class BaseEnumMeta(EnumMeta):
     _value_set: Optional[Set[Any]] = None
@@ -41,3 +43,13 @@ class AnnotationFormat(str, Enum, metaclass=BaseEnumMeta):
 class DatasetType(str, Enum, metaclass=BaseEnumMeta):
     ANNOTATED_DATA = "annotated_data"
     RAW_DATA = "raw_data"
+
+
+class ExcludedNoneBaseModel(BaseModel):
+    def dict(self, **kwargs):
+        exclude_none = kwargs.pop("exclude_none", True)
+        exclude_unset = kwargs.pop("exclude_unset", True)
+        data = super().dict(
+            exclude_none=exclude_none, exclude_unset=exclude_unset, **kwargs
+        )
+        return data

--- a/visionai_data_format/schemas/utils/validators.py
+++ b/visionai_data_format/schemas/utils/validators.py
@@ -13,8 +13,6 @@ def mapping_attributes_type_value(attributes: Dict) -> Dict[str, Set]:
         if not data_list:
             continue
 
-        attr_type = "option" if attr_type == "vec" else attr_type
-
         for data in data_list:
             name = data.get("name").upper()
             key = f"{name}:{attr_type}"

--- a/visionai_data_format/schemas/utils/validators.py
+++ b/visionai_data_format/schemas/utils/validators.py
@@ -873,7 +873,6 @@ def validate_visionai_children(
     ontology_classes = set(ontology_data.keys())
     visionai_frames = visionai.get("frames", {})
     visionai_objects = visionai.get(root_key, {})
-
     extra_classes, classes_attributes_map = validate_classes(
         visionai=visionai,
         ontology_classes=ontology_classes,
@@ -882,7 +881,7 @@ def validate_visionai_children(
     )
 
     if extra_classes:
-        return f"Label with classes {extra_classes} doesn't accepted"
+        return f"Attribute {root_key} with classes {extra_classes} doesn't accepted"
 
     valid_attr, valid_attr_data = validate_attributes(
         classes_attributes_map, ontology_attributes_map

--- a/visionai_data_format/schemas/visionai_schema.py
+++ b/visionai_data_format/schemas/visionai_schema.py
@@ -840,12 +840,28 @@ class VisionAI(BaseModel):
         assert value, f" Value {value} is not allowed"
         return value
 
+    def dict(self, **kwargs):
+        exclude_none = kwargs.get("exclude_none", True)
+        exclude_unset = kwargs.get("exclude_unset", True)
+        data = super().dict(
+            exclude_none=exclude_none, exclude_unset=exclude_unset, **kwargs
+        )
+        return data
+
 
 class VisionAIModel(BaseModel):
     class Config:
         extra = Extra.forbid
 
     visionai: VisionAI
+
+    def dict(self, **kwargs):
+        exclude_none = kwargs.get("exclude_none", True)
+        exclude_unset = kwargs.get("exclude_unset", True)
+        data = super().dict(
+            exclude_none=exclude_none, exclude_unset=exclude_unset, **kwargs
+        )
+        return data
 
     def validate_with_ontology(self, ontology: Type[Ontology]) -> List[str]:
 

--- a/visionai_data_format/schemas/visionai_schema.py
+++ b/visionai_data_format/schemas/visionai_schema.py
@@ -12,7 +12,6 @@ except ImportError:
     from typing_extensions import Literal  #
 
 from pydantic import (
-    BaseModel,
     Extra,
     Field,
     StrictBool,
@@ -23,6 +22,7 @@ from pydantic import (
     validator,
 )
 
+from visionai_data_format.schemas.common import ExcludedNoneBaseModel
 from visionai_data_format.schemas.ontology import Ontology
 from visionai_data_format.schemas.utils.validators import (
     build_ontology_attributes_map,
@@ -84,7 +84,7 @@ class StreamType(str, Enum):
     OTHER = "other"
 
 
-class Attributes(BaseModel):
+class Attributes(ExcludedNoneBaseModel):
     class Config:
         extra = Extra.forbid
 
@@ -94,7 +94,7 @@ class Attributes(BaseModel):
     vec: List[StaticVec] = Field(default_factory=list)
 
 
-class CoordinateSystemWRTParent(BaseModel):
+class CoordinateSystemWRTParent(ExcludedNoneBaseModel):
     matrix4x4: List[Union[float, int]]
 
     @validator("matrix4x4")
@@ -105,7 +105,7 @@ class CoordinateSystemWRTParent(BaseModel):
         return value
 
 
-class CoordinateSystem(BaseModel):
+class CoordinateSystem(ExcludedNoneBaseModel):
     type: CoordinateSystemType
     parent: StrictStr
     children: List[StrictStr]
@@ -121,7 +121,7 @@ class CoordinateSystem(BaseModel):
         return value
 
 
-class FrameInterval(BaseModel):
+class FrameInterval(ExcludedNoneBaseModel):
     class Config:
         extra = Extra.forbid
 
@@ -145,7 +145,7 @@ class FrameInterval(BaseModel):
         return values
 
 
-class IntrinsicsPinhole(BaseModel):
+class IntrinsicsPinhole(ExcludedNoneBaseModel):
     camera_matrix_3x4: List[float]
     distortion_coeffs_1xN: Optional[List[Union[float, int]]] = None
     height_px: int
@@ -164,7 +164,7 @@ class IntrinsicsPinhole(BaseModel):
         return value
 
 
-class Metadata(BaseModel):
+class Metadata(ExcludedNoneBaseModel):
     class Config:
         use_enum_values = True
         extra = Extra.allow
@@ -174,7 +174,7 @@ class Metadata(BaseModel):
     )
 
 
-class StaticBoolean(BaseModel):
+class StaticBoolean(ExcludedNoneBaseModel):
 
     attributes: Optional[Attributes] = None
     name: StrictStr = Field(
@@ -206,7 +206,7 @@ class DynamicBoolean(StaticBoolean):
     )
 
 
-class StaticNum(BaseModel):
+class StaticNum(ExcludedNoneBaseModel):
     class Config:
         use_enum_values = True
         extra = Extra.forbid
@@ -239,7 +239,7 @@ class DynamicNum(StaticNum):
     )
 
 
-class StaticText(BaseModel):
+class StaticText(ExcludedNoneBaseModel):
     class Config:
         use_enum_values = True
         extra = Extra.forbid
@@ -271,7 +271,7 @@ class DynamicText(StaticText):
     )
 
 
-class VecBaseNoName(BaseModel):
+class VecBaseNoName(ExcludedNoneBaseModel):
     attributes: Optional[Attributes] = None
     type: Optional[TypeRange] = Field(
         None,
@@ -307,7 +307,7 @@ class DynamicVec(StaticVec):
     )
 
 
-class BaseStaticElementData(BaseModel):
+class BaseStaticElementData(ExcludedNoneBaseModel):
 
     boolean: Optional[List[StaticBoolean]] = Field(
         None, description='List of "boolean" that describe this object.'
@@ -323,7 +323,7 @@ class BaseStaticElementData(BaseModel):
     )
 
 
-class BaseDynamicElementData(BaseModel):
+class BaseDynamicElementData(ExcludedNoneBaseModel):
 
     boolean: Optional[List[DynamicBoolean]] = Field(
         None, description='List of "boolean" that describe this object.'
@@ -339,7 +339,7 @@ class BaseDynamicElementData(BaseModel):
     )
 
 
-class ElementDataPointer(BaseModel):
+class ElementDataPointer(ExcludedNoneBaseModel):
 
     attributes: Optional[Dict[StrictStr, AttributeType]] = Field(
         None,
@@ -373,7 +373,7 @@ class ContextDataPointer(ElementDataPointer):
     )
 
 
-class Context(BaseModel):
+class Context(ExcludedNoneBaseModel):
     class Config:
         extra = Extra.forbid
 
@@ -464,7 +464,7 @@ class ObjectDataStatic(BaseStaticElementData):
         extra = Extra.forbid
 
 
-class Object(BaseModel):
+class Object(ExcludedNoneBaseModel):
     class Config:
         extra = Extra.forbid
 
@@ -539,11 +539,11 @@ class Object(BaseModel):
         return values
 
 
-class StreamProperties(BaseModel):
+class StreamProperties(ExcludedNoneBaseModel):
     intrinsics_pinhole: IntrinsicsPinhole
 
 
-class TagData(BaseModel):
+class TagData(ExcludedNoneBaseModel):
     vec: List[StaticVec] = Field(...)
 
     @validator("vec")
@@ -554,7 +554,7 @@ class TagData(BaseModel):
         return values
 
 
-class Stream(BaseModel):
+class Stream(ExcludedNoneBaseModel):
     type: StreamType
     uri: Optional[StrictStr] = ""
     description: Optional[StrictStr] = ""
@@ -569,13 +569,13 @@ class Stream(BaseModel):
         return value
 
 
-class Tag(BaseModel):
+class Tag(ExcludedNoneBaseModel):
     ontology_uid: StrictStr
     type: StrictStr
     tag_data: TagData
 
 
-class TimeStampElement(BaseModel):
+class TimeStampElement(ExcludedNoneBaseModel):
     timestamp: str
 
     class Config:
@@ -588,11 +588,11 @@ class TimeStampElement(BaseModel):
         return value
 
 
-class StreamPropertyUnderFrameProperty(BaseModel):
+class StreamPropertyUnderFrameProperty(ExcludedNoneBaseModel):
     sync: Optional[TimeStampElement] = None
 
 
-class FramePropertyStream(BaseModel):
+class FramePropertyStream(ExcludedNoneBaseModel):
     uri: str = Field(description="the urls of image")
     stream_properties: Optional[StreamPropertyUnderFrameProperty] = Field(
         None, description="Additional properties of the stream"
@@ -607,7 +607,7 @@ class FramePropertyStream(BaseModel):
         return value
 
 
-class FrameProperties(BaseModel):
+class FrameProperties(ExcludedNoneBaseModel):
     timestamp: Optional[str] = Field(
         None,
         descriptions="A relative or absolute time reference that specifies "
@@ -616,7 +616,7 @@ class FrameProperties(BaseModel):
     streams: Dict[StrictStr, FramePropertyStream]
 
 
-class ObjectDataElement(BaseModel):
+class ObjectDataElement(ExcludedNoneBaseModel):
 
     attributes: Optional[Attributes] = None
     name: StrictStr = Field(
@@ -707,7 +707,7 @@ class Binary(ObjectDataElement):
         return value
 
 
-class DynamicObjectData(BaseModel):
+class DynamicObjectData(ExcludedNoneBaseModel):
     class Config:
         extra = Extra.forbid
 
@@ -729,15 +729,15 @@ class DynamicObjectData(BaseModel):
     )
 
 
-class ObjectUnderFrame(BaseModel):
+class ObjectUnderFrame(ExcludedNoneBaseModel):
     object_data: DynamicObjectData
 
 
-class ContextUnderFrame(BaseModel):
+class ContextUnderFrame(ExcludedNoneBaseModel):
     context_data: DynamicContextData
 
 
-class Frame(BaseModel):
+class Frame(ExcludedNoneBaseModel):
     class Config:
         extra = Extra.forbid
 
@@ -760,7 +760,7 @@ class Frame(BaseModel):
     )
 
 
-class VisionAI(BaseModel):
+class VisionAI(ExcludedNoneBaseModel):
     class Config:
         extra = Extra.forbid
 
@@ -840,28 +840,12 @@ class VisionAI(BaseModel):
         assert value, f" Value {value} is not allowed"
         return value
 
-    def dict(self, **kwargs):
-        exclude_none = kwargs.get("exclude_none", True)
-        exclude_unset = kwargs.get("exclude_unset", True)
-        data = super().dict(
-            exclude_none=exclude_none, exclude_unset=exclude_unset, **kwargs
-        )
-        return data
 
-
-class VisionAIModel(BaseModel):
+class VisionAIModel(ExcludedNoneBaseModel):
     class Config:
         extra = Extra.forbid
 
     visionai: VisionAI
-
-    def dict(self, **kwargs):
-        exclude_none = kwargs.get("exclude_none", True)
-        exclude_unset = kwargs.get("exclude_unset", True)
-        data = super().dict(
-            exclude_none=exclude_none, exclude_unset=exclude_unset, **kwargs
-        )
-        return data
 
     def validate_with_ontology(self, ontology: Type[Ontology]) -> List[str]:
 

--- a/visionai_data_format/schemas/visionai_schema.py
+++ b/visionai_data_format/schemas/visionai_schema.py
@@ -199,6 +199,11 @@ class DynamicBoolean(StaticBoolean):
         ...,
         description="Name of the stream in respect of which this object data is expressed.",
     )
+    confidence_score: Optional[float] = Field(
+        None,
+        description="The confidence score of model prediction of this object."
+        + " Ground truth does not have this attribute.",
+    )
 
 
 class StaticNum(BaseModel):
@@ -227,6 +232,11 @@ class DynamicNum(StaticNum):
         ...,
         description="Name of the stream in respect of which this object data is expressed.",
     )
+    confidence_score: Optional[float] = Field(
+        None,
+        description="The confidence score of model prediction of this object."
+        + " Ground truth does not have this attribute.",
+    )
 
 
 class StaticText(BaseModel):
@@ -252,6 +262,12 @@ class DynamicText(StaticText):
     stream: StrictStr = Field(
         ...,
         description="Name of the stream in respect of which this object data is expressed.",
+    )
+
+    confidence_score: Optional[float] = Field(
+        None,
+        description="The confidence score of model prediction of this object."
+        + " Ground truth does not have this attribute.",
     )
 
 
@@ -283,6 +299,11 @@ class DynamicVec(StaticVec):
     stream: StrictStr = Field(
         ...,
         description="Name of the stream in respect of which this object data is expressed.",
+    )
+    confidence_score: Optional[float] = Field(
+        None,
+        description="The confidence score of model prediction of this object."
+        + " Ground truth does not have this attribute.",
     )
 
 


### PR DESCRIPTION
## Purpose

fix visionai-data-format from missing attributes and wrong logic of validation.
[AB#13919](https://dev.azure.com/linkerengineer/Dataverse/_sprints/taskboard/Dataverse%20Team/Dataverse/Sprint%2035%20-%20Data%20Query%20Logic?workitem=13919)

## What Changes?
- add `confidence_score` field for dynamic `context` objects
- remove unused replacement of attribute's name, since we let the user build the project ontology with our ontology. ( `option` in dataverse equals with `vec` attribute. we don't need to replace it anymore since we have our own ontology)
- allow all basemodel to exclude none value automatically when calling `.dict()` or `.json()` function 

## What to Check?

it should work. Dataverse could import dataset normally.

`.dict()`
![image](https://github.com/linkernetworks/visionai-data-format/assets/94961931/1b5824a4-f980-45c4-86a3-34c0aa79ce3a)

`.json()`
![image](https://github.com/linkernetworks/visionai-data-format/assets/94961931/2c6874a8-0c2d-4ceb-b6e9-b2659f66bfef)


