### PR TITLE
fix(python): modify retrieve object data method from frames

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "visionai-data-format"
-PACKAGE_VERSION = "1.0.2"
+PACKAGE_VERSION = "1.0.3"
 DESC = "converter tool for visionai format"
 REQUIRED = ["pydantic"]
 REQUIRES_PYTHON = ">=3.7, <4"

--- a/visionai_data_format/coco_to_vai.py
+++ b/visionai_data_format/coco_to_vai.py
@@ -120,6 +120,7 @@ def _coco_to_vision_ai(
                 )
             )
         }
+
         frames[image_name].objects.update(objects_under_frames)
 
         # to vision_ai: objects
@@ -160,8 +161,9 @@ def _coco_to_vision_ai(
     }
     # to vision_ai:
     for image_name, frame_obj in frames.items():
+        current_frame_objects = getattr(frame_obj, "objects", None) or {}
         objects_per_image = {
-            object_id: objects[object_id] for object_id in frame_obj.objects
+            object_id: objects[object_id] for object_id in current_frame_objects
         }
 
         new_image_name = f"{int(image_name):012d}"

--- a/visionai_data_format/utils/converter.py
+++ b/visionai_data_format/utils/converter.py
@@ -69,7 +69,8 @@ def convert_vai_to_bdd_single(
         cur_data["name"] = frame_key + ".jpg"
         labels = []
         idx = 0
-        for obj_id, obj_data in frame_data.objects.items():
+        objects = getattr(frame_data, "objects", None) or {}
+        for obj_id, obj_data in objects.items():
             classes = vai_data.objects.get(obj_id).type
             bboxes = obj_data.object_data.bbox or [] if obj_data.object_data else []
             for bbox in bboxes:


### PR DESCRIPTION
## Purpose

Modify `objects` retrieval method in case the `Frames` attribute doesn't contains `objects` key information.

Bug found by @yihsuan123 

[AB#14017](https://dev.azure.com/linkerengineer/Dataverse/_sprints/taskboard/Dataverse%20Team/Dataverse/Sprint%2035%20-%20Data%20Query%20Logic?workitem=14017)

## What Changes?

- add validation to check whether current frame contains objects attribute with `getattribute`

## What to Check?

it should work,  could access frame in case there is not `objects` attribute