### PR TITLE
fix(python): convert visionai data to bdd format (considering camera and bbox only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,15 @@ print(errors)
 
 First, create a new `Ontology` that contains the project ontology. Then, call `validate_with_ontology(ontology=validated_ontology)` to validate whether current `VisionAI` data meets the `Ontology` data information. It will returns list of error messages if any error occured, otherwise it returns empty list.
 
+
+## Tools
+### Convert `VisionAI` format data to `BDD` format
+The script below could help convert `VisionAI` annotation data to `BDD` json file
+```
+python visionai_data_format/vai_to_bdd.py -vai_src_folder /path_for_visionai_root_folder -bdd_dest_file /dest_path/bdd.json -company_code 99 -storage_name storge1 -container_name dataset1 -annotation_name groundtruth
+```
+
+
 ## Troubleshooting
 
 (WIP)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ AUTHOR = "LinkerVision"
 PACKAGE_NAME = "visionai-data-format"
 PACKAGE_VERSION = "1.0.4"
 DESC = "converter tool for visionai format"
-REQUIRED = ["pydantic"]
+REQUIRED = ["pydantic==1.*"]
 REQUIRES_PYTHON = ">=3.7, <4"
 EXTRAS = {
     "test": [

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "visionai-data-format"
-PACKAGE_VERSION = "1.0.3"
+PACKAGE_VERSION = "1.0.4"
 DESC = "converter tool for visionai format"
 REQUIRED = ["pydantic"]
 REQUIRES_PYTHON = ">=3.7, <4"

--- a/visionai_data_format/vai_to_bdd.py
+++ b/visionai_data_format/vai_to_bdd.py
@@ -11,17 +11,17 @@ def vai_to_bdd(
     vai_src_folder: str,
     bdd_dest_file: str,
     company_code: int,
-    sequence_name: str,
     storage_name: str,
     container_name: str,
+    annotation_name:str
 ) -> None:
     try:
         bdd_data = convert_vai_to_bdd(
             folder_name=vai_src_folder,
             company_code=company_code,
-            sequence_name=sequence_name,
             storage_name=storage_name,
             container_name=container_name,
+            annotation_name=annotation_name
         )
         bdd = validate_bdd(data=bdd_data)
         save_as_json(bdd.dict(), file_name=bdd_dest_file)
@@ -50,12 +50,6 @@ if __name__ == "__main__":
         help="Company code information for BDD+",
     )
     parser.add_argument(
-        "-sequence_name",
-        type=str,
-        required=True,
-        help="Company code information for BDD+",
-    )
-    parser.add_argument(
         "-storage_name",
         type=str,
         required=True,
@@ -66,6 +60,13 @@ if __name__ == "__main__":
         type=str,
         required=True,
         help="Container name information for BDD+",
+    )
+    parser.add_argument(
+        "-annotation_name",
+        type=str,
+        required=True,
+        default="groundtruth",
+        help="annotation folder name in VAI",
     )
 
     FORMAT = "%(asctime)s[%(process)d][%(levelname)s] %(name)-16s : %(message)s"
@@ -83,7 +84,7 @@ if __name__ == "__main__":
         args.vai_src_folder,
         args.bdd_dest_file,
         args.company_code,
-        args.sequence_name,
         args.storage_name,
         args.container_name,
+        args.annotation_name,
     )


### PR DESCRIPTION
## Purpose
- The bdd converter need to be modified as the new version of VisionAI format have annotation folder for groundtruth/models.
- Previous version does not consider visionai format with multiple sensors.

## What to Check?
Run script as below.
``` Python
python visionai_data_format/vai_to_bdd.py -vai_src_folder /Users/yihsuanchen/Downloads/vai_test -bdd_dest_file /Users/yihsuanchen/Downloads/bdd_test4.json -company_code 99 -storage_name ss -container_name dataset -annotation_name groundtruth
``` 
The output bdd json is as below
![image](https://github.com/linkernetworks/visionai-data-format/assets/55373569/07b6beac-4ae8-43ab-a568-789bb77f6b6d)

