### PR TITLE
fix(python): remove skipping unwanted uuid data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "visionai-data-format"
-PACKAGE_VERSION = "1.0.4"
+PACKAGE_VERSION = "1.0.5"
 DESC = "converter tool for visionai format"
 REQUIRED = ["pydantic==1.*"]
 REQUIRES_PYTHON = ">=3.7, <4"

--- a/visionai_data_format/schemas/utils/validators.py
+++ b/visionai_data_format/schemas/utils/validators.py
@@ -392,10 +392,6 @@ def parse_dynamic_attrs(
         for uuid, data in frame_obj[root_key].items():
             for attr_type, attr_list in data[sub_root_key].items():
                 for attr in attr_list:
-                    # skip uuid that we doesn't want to validate
-                    # TODO: find better implementation
-                    if (uuid, attr["name"]) not in data_pointers:
-                        continue
                     dynamic_attrs[(uuid, attr["name"])][cur_frame_no] = {
                         "type": attr_type,
                         "val": attr["val"],
@@ -733,6 +729,34 @@ def validate_dynamic_attrs_data_pointer_semantic_values(
     return True, ""
 
 
+def generate_missing_attributes_error_message(
+    extra_attributes_name: Set[str],
+    missing_attributes_name: Set[str],
+    dynamic_attrs: dict,
+) -> str:
+    msg = ""
+    if extra_attributes_name:
+        msg += "Extra attributes from data pointers : \n"
+        for attr_name in extra_attributes_name:
+            if attr_name in dynamic_attrs:
+                msg += (
+                    f"{attr_name} with frames {list(dynamic_attrs[attr_name].keys())}\n"
+                )
+            else:
+                msg += f"{attr_name} \n"
+
+    if missing_attributes_name:
+        msg += "Missing attributes from data pointers : \n"
+        for attr_name in missing_attributes_name:
+            if attr_name in dynamic_attrs:
+                msg += (
+                    f"{attr_name} with frames {list(dynamic_attrs[attr_name].keys())}\n"
+                )
+            else:
+                msg += f"{attr_name} \n"
+    return msg
+
+
 def validate_visionai_data(
     data_under_vai: Dict,
     frames: Dict[str, Dict],
@@ -784,14 +808,12 @@ def validate_visionai_data(
     if combination_attrs ^ data_pointers_keys:
         extra_attributes_name: Set[str] = combination_attrs - data_pointers_keys
         missing_attributes_name: Set[str] = data_pointers_keys - combination_attrs
-        msg = ""
-        if extra_attributes_name:
-            msg += f"Extra attributes from data pointers : {extra_attributes_name} \n"
+        msg: str = generate_missing_attributes_error_message(
+            extra_attributes_name=extra_attributes_name,
+            missing_attributes_name=missing_attributes_name,
+            dynamic_attrs=dynamic_attrs,
+        )
 
-        if missing_attributes_name:
-            msg += (
-                f"Missing attributes from data pointers : {missing_attributes_name} \n"
-            )
         return False, msg
 
     # retrieve frame numbers

--- a/visionai_data_format/schemas/utils/validators.py
+++ b/visionai_data_format/schemas/utils/validators.py
@@ -730,14 +730,30 @@ def validate_dynamic_attrs_data_pointer_semantic_values(
 
 
 def generate_missing_attributes_error_message(
-    extra_attributes_name: Set[str],
-    missing_attributes_name: Set[str],
+    extra_attribute_names: Set[str],
+    missing_attribute_names: Set[str],
     dynamic_attrs: dict,
 ) -> str:
+    """Generate error messages of extra or missing attributes from existing dynamic attributes
+
+    Parameters
+    ----------
+    extra_attribute_names : Set[str]
+        names of extra attributes, attributes that don't exist under visionai objects/contexts
+    missing_attribute_names : Set[str]
+        names of missing attributes, attributes that don't used under visionai frames
+    dynamic_attrs : dict
+        dynamic attributes data
+
+    Returns
+    -------
+    str
+        error message
+    """
     msg = ""
-    if extra_attributes_name:
+    if extra_attribute_names:
         msg += "Extra attributes from data pointers : \n"
-        for attr_name in extra_attributes_name:
+        for attr_name in extra_attribute_names:
             if attr_name in dynamic_attrs:
                 msg += (
                     f"{attr_name} with frames {list(dynamic_attrs[attr_name].keys())}\n"
@@ -745,9 +761,9 @@ def generate_missing_attributes_error_message(
             else:
                 msg += f"{attr_name} \n"
 
-    if missing_attributes_name:
+    if missing_attribute_names:
         msg += "Missing attributes from data pointers : \n"
-        for attr_name in missing_attributes_name:
+        for attr_name in missing_attribute_names:
             if attr_name in dynamic_attrs:
                 msg += (
                     f"{attr_name} with frames {list(dynamic_attrs[attr_name].keys())}\n"


### PR DESCRIPTION
## Purpose

<!-- Briefly describe the purpose of this PR -->
remove skipping unwanted existing uuid object under `Frames` that doesn't included in objects under visionai.

<!-- Fill the task or bug ID in azure board AB#{ID} -->
[AB#15017](https://dev.azure.com/linkerengineer/Dataverse/_sprints/taskboard/Dataverse%20Team/Dataverse/Sprint%2039%20-%20SAM%20Labeling%20Tool%20(2d%20Semantic%20Segmentation)?workitem=15017)

## Root Cause

<!-- If the PR is bug fix, please provide the root cause of the bug -->
- skipping unwanted existing uuid object doesn't raise error

## What Changes?

- fix skipping assign of unwanted uuid and attributes
- fix raise error message to add listing of error frames ( currently for this error)

## What to Check?

we could validate missing dynamic attributes under `Frames` from `Objects`/`Contexts` under `visionai`

- airflow raise error
<img width="1397" alt="image" src="https://github.com/linkernetworks/visionai/assets/94961931/c1ac1994-7024-4068-9d35-cf3913b836d0">

- listing frames number of error occurred( as mentioned by @JasperSui )
<img width="1411" alt="image" src="https://github.com/linkernetworks/visionai/assets/94961931/7c6ca07b-f760-447f-89b9-b068ec156c77">
