### PR TITLE
fix(python): modify frame_intervals under visionai validation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "visionai-data-format"
-PACKAGE_VERSION = "1.0.6"
+PACKAGE_VERSION = "1.0.7"
 DESC = "converter tool for visionai format"
 REQUIRED = ["pydantic==1.*"]
 REQUIRES_PYTHON = ">=3.7, <4"

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -119,9 +119,10 @@ def test_validate_wrong_visionai_frame_intervals(
     )
 
     assert errors == [
+        "Extra frames from `frame_intervals` : {1, 2}\n",
         "validate objects error: objects UUID 893ac389-7782-4bc3-8f61-09a8e48c819f with data pointer"
         + " bbox_shape frame interval(s) error, current data pointer interval (0, 2) "
-        + "doesn't match with objects interval [(0, 0)]"
+        + "doesn't match with objects interval [(0, 0)]",
     ]
 
 

--- a/visionai_data_format/schemas/utils/validators.py
+++ b/visionai_data_format/schemas/utils/validators.py
@@ -66,6 +66,41 @@ def parse_visionai_child_type(
     return classes_attributes_map
 
 
+def validate_visionai_intervals(visionai: Dict) -> Optional[str]:
+    """Validate frame intervals under visionai with its frames
+
+    Parameters
+    ----------
+    visionai : Dict
+        visionai data in dictionary
+
+    Returns
+    -------
+    Optional[str]
+        error message
+    """
+    msg: Optional[str] = None
+
+    visionai_frame_interval_set = {
+        frame_num
+        for frame_interval in visionai["frame_intervals"]
+        for frame_num in range(
+            frame_interval["frame_start"], frame_interval["frame_end"] + 1
+        )
+    }
+    frame_num_set = {int(frame_num) for frame_num in visionai["frames"].keys()}
+
+    if visionai_frame_interval_set ^ frame_num_set:
+        extra_frames = frame_num_set - visionai_frame_interval_set
+        missing_frames = visionai_frame_interval_set - frame_num_set
+        msg = ""
+        if extra_frames:
+            msg += f"Extra frames from `frame_intervals` : {extra_frames}\n"
+        if missing_frames:
+            msg += f"Missing frames from `frame_intervals` : {missing_frames}\n"
+    return msg
+
+
 def validate_classes(
     visionai: Dict,
     root_key: str,
@@ -494,7 +529,7 @@ def validate_vai_data_frame_intervals(
     data_obj_under_vai_intervals: Dict[str, List],
     visionai_frame_intervals: List[Tuple[int, int]],
 ) -> Tuple[bool, str]:
-    """_summary_
+    """validate frame intervals of object/context under visionai
 
     Parameters
     ----------
@@ -822,11 +857,11 @@ def validate_visionai_data(
     # validate if combinations of static and dynamic equals to data pointers
     combination_attrs = static_attrs_keys | dynamic_attrs_keys
     if combination_attrs ^ data_pointers_keys:
-        extra_attributes_name: Set[str] = combination_attrs - data_pointers_keys
-        missing_attributes_name: Set[str] = data_pointers_keys - combination_attrs
+        extra_attribute_names: Set[str] = combination_attrs - data_pointers_keys
+        missing_attribute_names: Set[str] = data_pointers_keys - combination_attrs
         msg: str = generate_missing_attributes_error_message(
-            extra_attributes_name=extra_attributes_name,
-            missing_attributes_name=missing_attributes_name,
+            extra_attribute_names=extra_attribute_names,
+            missing_attribute_names=missing_attribute_names,
             dynamic_attrs=dynamic_attrs,
         )
 

--- a/visionai_data_format/schemas/visionai_schema.py
+++ b/visionai_data_format/schemas/visionai_schema.py
@@ -29,6 +29,7 @@ from visionai_data_format.schemas.utils.validators import (
     validate_contexts,
     validate_objects,
     validate_streams,
+    validate_visionai_intervals,
 )
 
 
@@ -852,6 +853,10 @@ class VisionAIModel(ExcludedNoneBaseModel):
         tags = ontology.get("tags", {})
 
         visionai = self.visionai.dict(exclude_unset=True, exclude_none=True)
+
+        err = validate_visionai_intervals(visionai=visionai)
+        if err:
+            errors.append(err)
 
         streams_data = ontology["streams"]
 


### PR DESCRIPTION
## Purpose

add missing `frame_intervals` validation under visionai with `frames` number
[AB#15108](https://dev.azure.com/linkerengineer/Dataverse/_sprints/taskboard/Dataverse%20Team/Dataverse/Sprint%2041%20-%20SAAS%20and%20SAM%20Labeling%20Tool%20(2d%20%EF%BC%86%203d%20Cuboid)?workitem=15108)


## What Changes?
- add validation for frames intervals with visionai frames number
- modify test

## What to Check?

- It should work.

we could validate wrong `frame_interval` under visionai with its frames number
( `fake_objects_data_single_lidar_wrong_visionai_frame_intervals` is a visionai data with `frame_intervals` and its frames number doesn't match)
![image](https://github.com/linkernetworks/visionai-data-format/assets/94961931/b33b32ed-95b4-42b2-8458-166478d88f6c)
