### PR TITLE
fix(python): add `Frame` validator to avoid none or empty value

### DIFF
--- a/visionai_data_format/schemas/visionai_schema.py
+++ b/visionai_data_format/schemas/visionai_schema.py
@@ -782,8 +782,9 @@ class VisionAI(ExcludedNoneBaseModel):
 
     @validator("frames")
     def validate_frames(cls, value):
-        frame_keys = list(value.keys())
+        assert value, f"value {value} is not allowed"
 
+        frame_keys = list(value.keys())
         assert all(
             len(key) == 12 and key.isdigit() for key in frame_keys
         ), "Key must be a digit with 12 characters length"


### PR DESCRIPTION
## Purpose

add missing `Frames` validation to avoid none or empty value
[AB#15519](https://dev.azure.com/linkerengineer/Dataverse/_sprints/taskboard/Dataverse%20Team/Dataverse/Sprint%2041%20-%20SAAS%20and%20SAM%20Labeling%20Tool%20(2d%20%EF%BC%86%203d%20Cuboid)?workitem=15519)


## What Changes?
- add validation for empty value


## What to Check?

- It should work. Could show error for empty frames

<img width="1057" alt="image" src="https://github.com/linkernetworks/visionai-data-format/assets/94961931/26df442f-54e6-4277-a138-40bb24957f37">

