### PR TITLE
fix(python): modify parse static attributes logic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "visionai-data-format"
-PACKAGE_VERSION = "1.0.8"
+PACKAGE_VERSION = "1.0.9"
 DESC = "converter tool for visionai format"
 REQUIRED = ["pydantic==1.*"]
 REQUIRES_PYTHON = ">=3.7, <4"

--- a/tests/test_data/fake_contexts_data.json
+++ b/tests/test_data/fake_contexts_data.json
@@ -1,46 +1,42 @@
 {
     "visionai": {
-        "contexts": {
-            "25fd92e8-4730-47ae-a7b8-8ecd64b4886a": {
-                "frame_intervals": [
-                    {
-                        "frame_start": 0,
-                        "frame_end": 0
-                    }
-                ],
-                "name": "scene",
-                "context_data_pointers": {
-                    "weather": {
-                        "attributes": null,
-                        "frame_intervals": [
-                            {
-                                "frame_start": 0,
-                                "frame_end": 0
-                            }
-                        ],
-                        "type": "vec"
-                    }
-                },
-                "type": "scene"
-            }
-        },
-        "frame_intervals": [
-            {
-                "frame_start": 0,
-                "frame_end": 0
-            }
-        ],
         "frames": {
             "000000000000": {
                 "contexts": {
-                    "25fd92e8-4730-47ae-a7b8-8ecd64b4886a": {
+                    "01f79336-4ab6-4916-9e63-a2427282b1c9": {
                         "context_data": {
                             "vec": [
                                 {
-                                    "name": "weather",
                                     "val": [
-                                        "dew"
+                                        "daytime"
                                     ],
+                                    "name": "timeofday",
+                                    "stream": "camera1"
+                                }
+                            ]
+                        }
+                    },
+                    "0fb39044-72b8-4880-8556-02479f0637f5": {
+                        "context_data": {
+                            "vec": [
+                                {
+                                    "val": [
+                                        "rainy"
+                                    ],
+                                    "name": "weather",
+                                    "stream": "camera1"
+                                }
+                            ]
+                        }
+                    },
+                    "6e68a3ba-268e-4d1e-a892-db3aae03f95c": {
+                        "context_data": {
+                            "vec": [
+                                {
+                                    "val": [
+                                        "gasstations"
+                                    ],
+                                    "name": "scene",
                                     "stream": "camera1"
                                 }
                             ]
@@ -48,10 +44,9 @@
                     }
                 },
                 "frame_properties": {
-                    "timestamp": null,
                     "streams": {
                         "camera1": {
-                            "uri": "https://helenmlopsstorageqatest.blob.core.windows.net/demodataset/context/weather/000000000000/data/camera1/000000000000.jpg"
+                            "uri": "https: //dataverse-staging-bucket.s3.ap-northeast-1.amazonaws.com/backend/upload/datasets/qatest-20230809025824317467/data/000000000003/data/camera1/000000000000.jpg"
                         }
                     }
                 }
@@ -59,13 +54,90 @@
         },
         "streams": {
             "camera1": {
-                "type": "camera",
-                "uri": "",
-                "description": ""
+                "uri": "https://dataverse-staging-bucket.s3.ap-northeast-1.amazonaws.com/backend/upload/datasets/qatest-20230809025824317467/data/000000000003/data/camera1/000000000000.jpg",
+                "type": "camera"
+            }
+        },
+        "contexts": {
+            "01f79336-4ab6-4916-9e63-a2427282b1c9": {
+                "name": "*auto_tagging",
+                "type": "*tagging",
+                "frame_intervals": [
+                    {
+                        "frame_end": 0,
+                        "frame_start": 0
+                    }
+                ],
+                "context_data_pointers": {
+                    "timeofday": {
+                        "type": "vec",
+                        "frame_intervals": [
+                            {
+                                "frame_end": 0,
+                                "frame_start": 0
+                            }
+                        ]
+                    }
+                }
+            },
+            "0fb39044-72b8-4880-8556-02479f0637f5": {
+                "name": "*auto_tagging",
+                "type": "*tagging",
+                "frame_intervals": [
+                    {
+                        "frame_end": 0,
+                        "frame_start": 0
+                    }
+                ],
+                "context_data_pointers": {
+                    "weather": {
+                        "type": "vec",
+                        "frame_intervals": [
+                            {
+                                "frame_end": 0,
+                                "frame_start": 0
+                            }
+                        ]
+                    }
+                }
+            },
+            "6e68a3ba-268e-4d1e-a892-db3aae03f95c": {
+                "name": "*auto_tagging",
+                "type": "*tagging",
+                "frame_intervals": [
+                    {
+                        "frame_end": 0,
+                        "frame_start": 0
+                    }
+                ],
+                "context_data_pointers": {
+                    "scene": {
+                        "type": "vec",
+                        "frame_intervals": [
+                            {
+                                "frame_end": 0,
+                                "frame_start": 0
+                            }
+                        ]
+                    }
+                }
             }
         },
         "metadata": {
             "schema_version": "1.0.0"
+        },
+        "frame_intervals": [
+            {
+                "frame_end": 0,
+                "frame_start": 0
+            }
+        ],
+        "coordinate_systems": {
+            "camera1": {
+                "type": "sensor_cs",
+                "parent": "",
+                "children": []
+            }
         }
     }
 }

--- a/tests/test_data/fake_contexts_data.json
+++ b/tests/test_data/fake_contexts_data.json
@@ -9,17 +9,6 @@
                     }
                 ],
                 "name": "scene",
-                "context_data": {
-                    "vec": [
-                        {
-                            "name": "weather",
-                            "type": null,
-                            "val": [
-                                "dew"
-                            ]
-                        }
-                    ]
-                },
                 "context_data_pointers": {
                     "weather": {
                         "attributes": null,

--- a/tests/test_data/fake_visionai_classification_ontology.json
+++ b/tests/test_data/fake_visionai_classification_ontology.json
@@ -1,5 +1,5 @@
 {
-    "objects":{
+    "contexts":{
         "scene":{
             "attributes":{
                 "weather":{

--- a/tests/test_data/fake_visionai_classification_ontology.json
+++ b/tests/test_data/fake_visionai_classification_ontology.json
@@ -1,24 +1,42 @@
 {
-    "contexts":{
-        "scene":{
-            "attributes":{
-                "weather":{
-                    "type":"vec",
-                    "value":[
-                        "dew",
-                        "fogsmog",
-                        "frost",
-                        "glaze",
-                        "hail",
-                        "lightning",
-                        "rain",
-                        "rainbow",
-                        "rime",
-                        "sandstorm",
-                        "snow"
+    "contexts": {
+        "*tagging": {
+            "attributes": {
+                "weather": {
+                    "type": "vec",
+                    "value": [
+                        "sunny",
+                        "cloudy",
+                        "rainy",
+                        "snowy",
+                        "foggy"
+                    ]
+                },
+                "timeofday": {
+                    "type": "vec",
+                    "value": [
+                        "daytime",
+                        "night",
+                        "dawndusk"
+                    ]
+                },
+                "scene": {
+                    "type": "vec",
+                    "value": [
+                        "tunnel",
+                        "residential",
+                        "parkingLot",
+                        "citystreet",
+                        "gasstations",
+                        "highway"
                     ]
                 }
             }
+        }
+    },
+    "objects": {
+        "dog": {
+            "attributes": {}
         }
     },
     "streams": {

--- a/visionai_data_format/schemas/utils/validators.py
+++ b/visionai_data_format/schemas/utils/validators.py
@@ -458,10 +458,14 @@ def parse_static_attrs(
     static_attrs: Dict[Tuple[str, str], Dict] = defaultdict(dict)
 
     for uuid, data in data_under_vai.items():
-        # skip accessing current data if
-        # only tags and type is not *tagging,
-        # or not only tags and current type is *tagging
-        # or current data doesn't contains object_data/context_data (no static attributes)
+        # we need to skip to parsing current contexts/objects static attributes
+        # if we meets below requirements:
+        # 1. when only parsing tags data, we will skip data with type is equal to "*tagging"
+        #    ,since project tag type in visionai is *tagging
+        # 2. when we need to parsing data unrelated with tags
+        #    we will skip data with type is not equal to "*tagging"
+        # 3. when current contexts/objects doesn't contains `context_data`/`object_data`,
+        #    we could skip current contexts/objects
         if (
             (only_tags and data["type"] != "*tagging")
             or (not only_tags and data["type"] == "*tagging")


### PR DESCRIPTION
## Purpose

fix parsing static attributes since objects/contexts under visionai could to not contains `object_data` or `context_data`. 
[AB#15681](https://dev.azure.com/linkerengineer/Dataverse/_sprints/taskboard/Dataverse%20Team/Dataverse/Sprint%2042%20-%20SAAS%20and%20SAM%20Labeling%20Tool%20(2d%20%EF%BC%86%203d%20Cuboid)?workitem=15681)

## What Changes?
- fix `parse_static_attrs` function to check whether current `objects` or `contexts` under visionai contains `object_data`/`context_data`, since `objects`/`contexts` could to not contains static attributes
- fix `parse_dynamic_attrs` function to remove unused parameter and update comments
- fix tests

## What to Check?

it should work. 

- Export dataslice in dataverse could works normally.
![image](https://github.com/linkernetworks/visionai-data-format/assets/94961931/c089fa22-963d-40aa-878a-422e64c27011)


- Exported dataslice could be imported normally.
![image](https://github.com/linkernetworks/visionai-data-format/assets/94961931/e3c447cf-ebe6-4643-8945-d883cf822d8d)
