### PR TITLE
fix(python): fix wrong validation process of attributes info

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -112,3 +112,9 @@ def fake_objects_data_single_lidar_wrong_objects_frame_intervals():
 def fake_contexts_data_wrong_vector_value():
     file_name = "fake_contexts_data_wrong_vector_value.json"
     return json.load(open(os.path.join(TEST_DATA_FOLDER, file_name)))
+
+
+@pytest.fixture(scope="session")
+def fake_contexts_classification_wrong_vector_value():
+    file_name = "fake_contexts_classification_wrong_vector_value.json"
+    return json.load(open(os.path.join(TEST_DATA_FOLDER, file_name)))

--- a/conftest.py
+++ b/conftest.py
@@ -106,3 +106,9 @@ def fake_objects_data_single_lidar_wrong_visionai_frame_intervals():
 def fake_objects_data_single_lidar_wrong_objects_frame_intervals():
     file_name = "fake_objects_data_single_lidar_wrong_objects_frame_intervals.json"
     return json.load(open(os.path.join(TEST_DATA_FOLDER, file_name)))
+
+
+@pytest.fixture(scope="session")
+def fake_contexts_data_wrong_vector_value():
+    file_name = "fake_contexts_data_wrong_vector_value.json"
+    return json.load(open(os.path.join(TEST_DATA_FOLDER, file_name)))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "visionai-data-format"
-PACKAGE_VERSION = "1.0.9"
+PACKAGE_VERSION = "1.0.10"
 DESC = "converter tool for visionai format"
 REQUIRED = ["pydantic==1.*"]
 REQUIRES_PYTHON = ">=3.7, <4"

--- a/tests/test_data/fake_contexts_classification_wrong_vector_value.json
+++ b/tests/test_data/fake_contexts_classification_wrong_vector_value.json
@@ -1,0 +1,143 @@
+{
+    "visionai": {
+        "frames": {
+            "000000000000": {
+                "contexts": {
+                    "01f79336-4ab6-4916-9e63-a2427282b1c9": {
+                        "context_data": {
+                            "vec": [
+                                {
+                                    "val": [
+                                        "asdfll"
+                                    ],
+                                    "name": "timeofday",
+                                    "stream": "camera1"
+                                }
+                            ]
+                        }
+                    },
+                    "0fb39044-72b8-4880-8556-02479f0637f5": {
+                        "context_data": {
+                            "vec": [
+                                {
+                                    "val": [
+                                        "rainy"
+                                    ],
+                                    "name": "weather",
+                                    "stream": "camera1"
+                                }
+                            ]
+                        }
+                    },
+                    "6e68a3ba-268e-4d1e-a892-db3aae03f95c": {
+                        "context_data": {
+                            "vec": [
+                                {
+                                    "val": [
+                                        "gasstations"
+                                    ],
+                                    "name": "scene",
+                                    "stream": "camera1"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "frame_properties": {
+                    "streams": {
+                        "camera1": {
+                            "uri": "https: //dataverse-staging-bucket.s3.ap-northeast-1.amazonaws.com/backend/upload/datasets/qatest-20230809025824317467/data/000000000003/data/camera1/000000000000.jpg"
+                        }
+                    }
+                }
+            }
+        },
+        "streams": {
+            "camera1": {
+                "uri": "https://dataverse-staging-bucket.s3.ap-northeast-1.amazonaws.com/backend/upload/datasets/qatest-20230809025824317467/data/000000000003/data/camera1/000000000000.jpg",
+                "type": "camera"
+            }
+        },
+        "contexts": {
+            "01f79336-4ab6-4916-9e63-a2427282b1c9": {
+                "name": "*auto_tagging",
+                "type": "*tagging",
+                "frame_intervals": [
+                    {
+                        "frame_end": 0,
+                        "frame_start": 0
+                    }
+                ],
+                "context_data_pointers": {
+                    "timeofday": {
+                        "type": "vec",
+                        "frame_intervals": [
+                            {
+                                "frame_end": 0,
+                                "frame_start": 0
+                            }
+                        ]
+                    }
+                }
+            },
+            "0fb39044-72b8-4880-8556-02479f0637f5": {
+                "name": "*auto_tagging",
+                "type": "*tagging",
+                "frame_intervals": [
+                    {
+                        "frame_end": 0,
+                        "frame_start": 0
+                    }
+                ],
+                "context_data_pointers": {
+                    "weather": {
+                        "type": "vec",
+                        "frame_intervals": [
+                            {
+                                "frame_end": 0,
+                                "frame_start": 0
+                            }
+                        ]
+                    }
+                }
+            },
+            "6e68a3ba-268e-4d1e-a892-db3aae03f95c": {
+                "name": "*auto_tagging",
+                "type": "*tagging",
+                "frame_intervals": [
+                    {
+                        "frame_end": 0,
+                        "frame_start": 0
+                    }
+                ],
+                "context_data_pointers": {
+                    "scene": {
+                        "type": "vec",
+                        "frame_intervals": [
+                            {
+                                "frame_end": 0,
+                                "frame_start": 0
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "metadata": {
+            "schema_version": "1.0.0"
+        },
+        "frame_intervals": [
+            {
+                "frame_end": 0,
+                "frame_start": 0
+            }
+        ],
+        "coordinate_systems": {
+            "camera1": {
+                "type": "sensor_cs",
+                "parent": "",
+                "children": []
+            }
+        }
+    }
+}

--- a/tests/test_data/fake_contexts_data_wrong_vector_value.json
+++ b/tests/test_data/fake_contexts_data_wrong_vector_value.json
@@ -1,0 +1,94 @@
+{
+    "visionai": {
+        "frames": {
+            "000000000000": {
+                "contexts": {
+                    "01f79336-4ab6-4916-9e63-a2427282b1c9": {
+                        "context_data": {
+                            "vec": [
+                                {
+                                    "val": [
+                                        "this_is_the_wrong_value"
+                                    ],
+                                    "name": "timeofday",
+                                    "stream": "camera1"
+                                },
+                                {
+                                    "val": [
+                                        "rainy"
+                                    ],
+                                    "name": "weather",
+                                    "stream": "camera1"
+                                }
+
+                            ]
+
+
+                        }
+                    }
+                },
+                "frame_properties": {
+                    "streams": {
+                        "camera1": {
+                            "uri": "https: //dataverse-staging-bucket.s3.ap-northeast-1.amazonaws.com/backend/upload/datasets/qatest-20230809025824317467/data/000000000003/data/camera1/000000000000.jpg"
+                        }
+                    }
+                }
+            }
+        },
+        "streams": {
+            "camera1": {
+                "uri": "https://dataverse-staging-bucket.s3.ap-northeast-1.amazonaws.com/backend/upload/datasets/qatest-20230809025824317467/data/000000000003/data/camera1/000000000000.jpg",
+                "type": "camera"
+            }
+        },
+        "contexts": {
+            "01f79336-4ab6-4916-9e63-a2427282b1c9": {
+                "name": "*auto_tagging",
+                "type": "*tagging",
+                "frame_intervals": [
+                    {
+                        "frame_end": 0,
+                        "frame_start": 0
+                    }
+                ],
+                "context_data_pointers": {
+                    "timeofday": {
+                        "type": "vec",
+                        "frame_intervals": [
+                            {
+                                "frame_end": 0,
+                                "frame_start": 0
+                            }
+                        ]
+                    },
+                    "weather": {
+                        "type": "vec",
+                        "frame_intervals": [
+                            {
+                                "frame_end": 0,
+                                "frame_start": 0
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "metadata": {
+            "schema_version": "1.0.0"
+        },
+        "frame_intervals": [
+            {
+                "frame_end": 0,
+                "frame_start": 0
+            }
+        ],
+        "coordinate_systems": {
+            "camera1": {
+                "type": "sensor_cs",
+                "parent": "",
+                "children": []
+            }
+        }
+    }
+}

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -143,3 +143,21 @@ def test_validate_wrong_object_frame_intervals(
         + " bbox_shape frame interval(s) error, current data pointer interval (0, 2) "
         + "doesn't match with objects interval [(0, 0)]"
     ]
+
+
+def test_validate_wrong_context_vector_attribute(
+    fake_visionai_classification_ontology, fake_contexts_data_wrong_vector_value
+):
+    ontology = Ontology(**fake_visionai_classification_ontology).dict(
+        exclude_unset=True
+    )
+
+    errors = VisionAIModel(
+        **fake_contexts_data_wrong_vector_value
+    ).validate_with_ontology(
+        ontology=ontology,
+    )
+    assert errors == [
+        "Attribute contexts error : class [*tagging] attribute error"
+        + " [TIMEOFDAY:vec] extra options : {'THIS_IS_THE_WRONG_VALUE'}"
+    ]

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -161,3 +161,22 @@ def test_validate_wrong_context_vector_attribute(
         "Attribute contexts error : class [*tagging] attribute error"
         + " [TIMEOFDAY:vec] extra options : {'THIS_IS_THE_WRONG_VALUE'}"
     ]
+
+
+def test_validate_wrong_context_vector_attribute_classification(
+    fake_visionai_classification_ontology,
+    fake_contexts_classification_wrong_vector_value,
+):
+    ontology = Ontology(**fake_visionai_classification_ontology).dict(
+        exclude_unset=True
+    )
+
+    errors = VisionAIModel(
+        **fake_contexts_classification_wrong_vector_value
+    ).validate_with_ontology(
+        ontology=ontology,
+    )
+    assert errors == [
+        "Attribute contexts error : class [*tagging] attribute error"
+        + " [TIMEOFDAY:vec] extra options : {'ASDFLL'}"
+    ]

--- a/visionai_data_format/schemas/utils/validators.py
+++ b/visionai_data_format/schemas/utils/validators.py
@@ -229,7 +229,7 @@ def validate_attributes(
             # Check whether attribute name in the excluded attributes set
             if (
                 excluded_attributes and label_attr_name.lower() in excluded_attributes
-            ) or label_attr_type.lower() != "option":
+            ) or label_attr_type.lower() != "vec":
                 continue
 
             ontology_attr_options: Set[str] = ontology_attr_name_type_dict.get(
@@ -242,8 +242,9 @@ def validate_attributes(
                 if not label_attr_options
                 else {str(opt).upper() for opt in label_attr_options}
             )
-            if not ontology_attr_options or (processed_options - ontology_attr_options):
-                return False, (label_class, label_attr_name_type)
+            extra_options = processed_options - ontology_attr_options
+            if not ontology_attr_options or extra_options:
+                return False, (label_class, label_attr_name_type, extra_options)
     return True, None
 
 
@@ -956,8 +957,11 @@ def validate_visionai_children(
         classes_attributes_map, ontology_attributes_map
     )
     if not valid_attr:
-        obj_cls, name_type = valid_attr_data
-        return f"Attribute {root_key} error : class [{obj_cls}] attribute error [{name_type}]"
+        obj_cls, name_type, extra_option = valid_attr_data
+        return (
+            f"Attribute {root_key} error : class [{obj_cls}] attribute error [{name_type}]"
+            + f"extra options : {extra_option}"
+        )
 
     sensor_name_set = set(sensor_info.keys())
     error_msg: Optional[str] = validate_frame_object_sensors_data(
@@ -981,9 +985,10 @@ def validate_visionai_children(
     )
 
     if not valid_attr:
-        obj_cls, name_type = valid_attr_data
+        obj_cls, name_type, extra_option = valid_attr_data
         return (
-            f"Attribute Object error : class [{obj_cls}] attribute error [{name_type}]"
+            f"Attribute {root_key} error : class [{obj_cls}] attribute error [{name_type}]"
+            + f" extra options : {extra_option}"
         )
 
     status, err = validate_visionai_data(

--- a/visionai_data_format/schemas/utils/validators.py
+++ b/visionai_data_format/schemas/utils/validators.py
@@ -348,8 +348,6 @@ def parse_visionai_frames_objects(
         return
     subroot_key = "object_data" if root_key == "objects" else "context_data"
     classes_attributes_map: Dict[str, Dict[str, Set]] = {}
-    print(f"subroot_key {subroot_key}")
-    print(f"frames {frames}")
     for data in frames.values():
         obj = data.get(root_key, None)
         if not obj:

--- a/visionai_data_format/schemas/utils/validators.py
+++ b/visionai_data_format/schemas/utils/validators.py
@@ -307,7 +307,9 @@ def get_frame_object_attr_type(
 
     obj_data_ele_set = {"bbox", "poly2d", "point2d", "binary"}
 
-    classes_attributes_map: Dict[str, Dict[str, Set]] = {}
+    classes_attributes_map: Dict[str, Dict[str, Set]] = defaultdict(
+        lambda: defaultdict(set)
+    )
     for obj_id, obj_data in frame_objects.items():
         global_object = all_objects.get(obj_id)
         if not global_object:
@@ -331,9 +333,8 @@ def get_frame_object_attr_type(
                     )
         else:
             mapped_attributes = mapping_attributes_type_value(data)
-
-        classes_attributes_map[obj_class] = mapped_attributes
-
+        for attribute_name_type, attribute_options in mapped_attributes.items():
+            classes_attributes_map[obj_class][attribute_name_type] |= attribute_options
     return classes_attributes_map
 
 
@@ -347,6 +348,8 @@ def parse_visionai_frames_objects(
         return
     subroot_key = "object_data" if root_key == "objects" else "context_data"
     classes_attributes_map: Dict[str, Dict[str, Set]] = {}
+    print(f"subroot_key {subroot_key}")
+    print(f"frames {frames}")
     for data in frames.values():
         obj = data.get(root_key, None)
         if not obj:
@@ -979,7 +982,6 @@ def validate_visionai_children(
     frames_attributes_map: Dict[str, Dict[str, Set]] = parse_visionai_frames_objects(
         visionai_frames, visionai_objects, root_key
     )
-
     valid_attr, valid_attr_data = validate_attributes(
         frames_attributes_map, ontology_attributes_map
     )

--- a/visionai_data_format/utils/converter.py
+++ b/visionai_data_format/utils/converter.py
@@ -190,22 +190,22 @@ def convert_bdd_to_vai(
                         frame_obj_attr["boolean"].append(
                             {"name": attr_name, "val": attr_value}
                         )
-                        object_data_pointers_attr[attr_name] = "boolean"
+                        object_data_pointers_attr[attr_name] = ObjectType.BOOLEAN
                     elif isinstance(attr_value, int):
                         frame_obj_attr["num"].append(
                             {"name": attr_name, "val": attr_value}
                         )
-                        object_data_pointers_attr[attr_name] = "num"
+                        object_data_pointers_attr[attr_name] = ObjectType.NUM
                     # TODO  usually we need vec type for str and list attributes
                     # might need to ask user to provide ontology to know which type they want (text / vec)
                     else:
-                        object_data_pointers_attr[attr_name] = "vec"
+                        object_data_pointers_attr[attr_name] = ObjectType.VEC
                         if isinstance(attr_value, list):
-                            frame_obj_attr["vec"].append(
+                            frame_obj_attr[ObjectType.VEC].append(
                                 {"name": attr_name, "val": attr_value}
                             )
                         else:
-                            frame_obj_attr["vec"].append(
+                            frame_obj_attr[ObjectType.VEC].append(
                                 {"name": attr_name, "val": [attr_value]}
                             )
 
@@ -274,7 +274,7 @@ def convert_bdd_to_vai(
                     }
                     if isinstance(attr_value, int):
                         context_poninters[context_id][attr_name] = {
-                            "type": "num",
+                            "type": ObjectType.NUM,
                             "frame_intervals": tagging_frame_intervals,
                         }
                         dynamic_context_data[context_id]["num"].append(context_item)
@@ -286,13 +286,15 @@ def convert_bdd_to_vai(
                         dynamic_context_data[context_id]["boolean"].append(context_item)
                     else:
                         context_poninters[context_id][attr_name] = {
-                            "type": "vec",
+                            "type": ObjectType.VEC,
                             "frame_intervals": tagging_frame_intervals,
                         }
                         if isinstance(attr_value, list):
-                            dynamic_context_data[context_id]["vec"].append(context_item)
+                            dynamic_context_data[context_id][ObjectType.VEC].append(
+                                context_item
+                            )
                         else:
-                            dynamic_context_data[context_id]["vec"].append(
+                            dynamic_context_data[context_id][ObjectType.VEC].append(
                                 {
                                     "name": attr_name,
                                     "val": [attr_value],


### PR DESCRIPTION
## Purpose

<!-- Briefly describe the purpose of this PR -->

we fix wrong declaration for `vec` ,  attribute with contains list of data, with `option`.  

Also fix wrong retrieval logic of attributes data.  In previous implementation, we only retrieve data without appending it.

![image](https://github.com/linkernetworks/visionai-data-format/assets/94961931/62b46acc-e173-40c6-8be2-9f4687a25965)

<!-- Fill the task or bug ID in azure board AB#{ID} -->
- [AB#15737](https://dev.azure.com/linkerengineer/Dataverse/_sprints/taskboard/Dataverse%20Team/Dataverse/Sprint%2042%20-%20SAAS%20and%20SAM%20Labeling%20Tool%20(2d%20%EF%BC%86%203d%20Cuboid)?workitem=15737)

## Root Cause

<!-- If the PR is bug fix, please provide the root cause of the bug -->

## What Changes?
- change wrong filter logic attribute of `option` type with `vec`. 
- fix `get_frame_object_attr_type` to combine multiple attributes for the same `obj_class` type 
- fix error message to show : class type, attributes which raise error, and the option values

## What to Check?

it should work, we could find error inside `contexts` attributes
![image](https://github.com/linkernetworks/visionai-data-format/assets/94961931/84c068fe-586d-4139-bb5b-0021e80e90e3)

we also save all of same class type of retrieved data
![image](https://github.com/linkernetworks/visionai-data-format/assets/94961931/81c26c02-dbf0-45c2-bd33-42442f5563d3)


